### PR TITLE
Fix crashes in the absence of a git repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Before you submit a PR, make sure your tests are passing, and that the code is p
 ```
 sbt prepare
 
-sbt test
+sbt testPlugin
 ```
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -37,6 +37,7 @@ inThisBuild(
 
 ThisBuild / publishTo := sonatypePublishToBundle.value
 
+addCommandAlias("testPlugin", "scripted; test")
 addCommandAlias("prepare", "fix; fmt")
 addCommandAlias("fmt", "all scalafmtSbt scalafmtAll")
 addCommandAlias("fmtCheck", "all scalafmtSbtCheck scalafmtCheckAll")
@@ -66,6 +67,13 @@ lazy val zioSbtWebsite =
     .in(file("zio-sbt-website"))
     .settings(stdSettings("zio-sbt-website"))
     .settings(buildInfoSettings("zio.sbt"))
+    .settings(
+      scriptedLaunchOpts := {
+        scriptedLaunchOpts.value ++
+          Seq("-Xmx1024M", "-Dplugin.version=" + version.value)
+      },
+      scriptedBufferLog := false
+    )
     .enablePlugins(SbtPlugin)
 
 lazy val docs = project

--- a/zio-sbt-website/src/sbt-test/zio-sbt-website/compileDocs/build.sbt
+++ b/zio-sbt-website/src/sbt-test/zio-sbt-website/compileDocs/build.sbt
@@ -1,0 +1,4 @@
+lazy val root = (project in file("."))
+  .settings(
+    version := "0.1",
+  ).enablePlugins(WebsitePlugin)

--- a/zio-sbt-website/src/sbt-test/zio-sbt-website/compileDocs/docs/index.md
+++ b/zio-sbt-website/src/sbt-test/zio-sbt-website/compileDocs/docs/index.md
@@ -1,0 +1,7 @@
+---
+id: index
+title: "Introduction to ZIO SBT"
+sidebar_label: "Introduction"
+---
+
+SBT Plugin for ZIO Projects.

--- a/zio-sbt-website/src/sbt-test/zio-sbt-website/compileDocs/docs/package.json
+++ b/zio-sbt-website/src/sbt-test/zio-sbt-website/compileDocs/docs/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@zio.dev/zio-sbt",
+  "description": "ZIO SBT Documentation",
+  "license": "Apache-2.0"
+}

--- a/zio-sbt-website/src/sbt-test/zio-sbt-website/compileDocs/docs/sidebar.js
+++ b/zio-sbt-website/src/sbt-test/zio-sbt-website/compileDocs/docs/sidebar.js
@@ -1,0 +1,7 @@
+const sidebars = {
+  sidebar: [
+    'index'
+  ]
+};
+
+module.exports = sidebars;

--- a/zio-sbt-website/src/sbt-test/zio-sbt-website/compileDocs/project/plugins.sbt
+++ b/zio-sbt-website/src/sbt-test/zio-sbt-website/compileDocs/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("dev.zio" % "zio-sbt-website" % x)
+  case _       => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/zio-sbt-website/src/sbt-test/zio-sbt-website/compileDocs/src/main/scala/Main.scala
+++ b/zio-sbt-website/src/sbt-test/zio-sbt-website/compileDocs/src/main/scala/Main.scala
@@ -1,0 +1,3 @@
+object Main {
+  def main(args: Array[String]): Unit = println("hello, zio")
+}

--- a/zio-sbt-website/src/sbt-test/zio-sbt-website/compileDocs/test
+++ b/zio-sbt-website/src/sbt-test/zio-sbt-website/compileDocs/test
@@ -1,0 +1,8 @@
+> clean
+> compile
+> compileDocs
+$ exists target/website/docs
+$ exists target/website/docs/index.md
+$ exists target/website/docs/package.json
+$ exists target/website/docs/sidebar.js
+ 

--- a/zio-sbt-website/src/sbt-test/zio-sbt-website/installWebsite/build.sbt
+++ b/zio-sbt-website/src/sbt-test/zio-sbt-website/installWebsite/build.sbt
@@ -1,0 +1,4 @@
+lazy val root = (project in file("."))
+  .settings(
+    version := "0.1",
+  ).enablePlugins(WebsitePlugin)

--- a/zio-sbt-website/src/sbt-test/zio-sbt-website/installWebsite/docs/index.md
+++ b/zio-sbt-website/src/sbt-test/zio-sbt-website/installWebsite/docs/index.md
@@ -1,0 +1,7 @@
+---
+id: index
+title: "Introduction to ZIO SBT"
+sidebar_label: "Introduction"
+---
+
+SBT Plugin for ZIO Projects.

--- a/zio-sbt-website/src/sbt-test/zio-sbt-website/installWebsite/docs/package.json
+++ b/zio-sbt-website/src/sbt-test/zio-sbt-website/installWebsite/docs/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@zio.dev/zio-sbt",
+  "description": "ZIO SBT Documentation",
+  "license": "Apache-2.0"
+}

--- a/zio-sbt-website/src/sbt-test/zio-sbt-website/installWebsite/docs/sidebar.js
+++ b/zio-sbt-website/src/sbt-test/zio-sbt-website/installWebsite/docs/sidebar.js
@@ -1,0 +1,7 @@
+const sidebars = {
+  sidebar: [
+    'index'
+  ]
+};
+
+module.exports = sidebars;

--- a/zio-sbt-website/src/sbt-test/zio-sbt-website/installWebsite/project/plugins.sbt
+++ b/zio-sbt-website/src/sbt-test/zio-sbt-website/installWebsite/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("dev.zio" % "zio-sbt-website" % x)
+  case _       => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/zio-sbt-website/src/sbt-test/zio-sbt-website/installWebsite/src/main/scala/Main.scala
+++ b/zio-sbt-website/src/sbt-test/zio-sbt-website/installWebsite/src/main/scala/Main.scala
@@ -1,0 +1,3 @@
+object Main {
+  def main(args: Array[String]): Unit = println("hello, zio")
+}

--- a/zio-sbt-website/src/sbt-test/zio-sbt-website/installWebsite/test
+++ b/zio-sbt-website/src/sbt-test/zio-sbt-website/installWebsite/test
@@ -1,0 +1,5 @@
+> clean
+> installWebsite
+$ exists target/website/src 
+$ exists target/website/static 
+$ exists target/website/LICENSE 


### PR DESCRIPTION
  * 'releaseVersion' now resilient against missing git repo.
  * Added Scripted plugin tests for 'compileDocs' and 'installWebsite'.
  * Fixed bad 'rm -rvf' command, flags were in the wrong place.