### PR TITLE
Changes to Scala 3 version handling per discussion with Rob Walsh.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,11 @@ env:
 
 on:
   pull_request:
+    branches: ['**']
+    types: [opened, synchronize, reopened, edited, labeled]
   push:
-    branches: ['main']
+    branches: ['**']
+    tags: [v*]
   release:
     types:
       - published
@@ -37,8 +40,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: ['adopt@1.8', 'adopt@1.11']
-        scala: ['2.12.17']
+        java: ["adopt@1.8", "adopt@1.11"]
+        scala: ["2.12.17"]
     steps:
     - uses: actions/checkout@v3.3.0
     - uses: olafurpg/setup-scala@v13
@@ -48,12 +51,14 @@ jobs:
       uses: coursier/cache-action@v6
     - name: Run tests
       run: sbt ++${{ matrix.scala }}! test
-          
+    - name: Run Scripted plugin tests
+      run: sbt testPlugins
+
   publish:
     runs-on: ubuntu-20.04
     timeout-minutes: 30
-    needs: [build,lint]
-    if: github.event_name != 'pull_request'
+    needs: [build, lint]
+    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
     steps:
       - uses: actions/checkout@v3.3.0
         with:

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,15 @@
+import zio.sbt.Commands._
 sbtPlugin         := true
 publishMavenStyle := true
 
 enablePlugins(ZioEcosystemProjectPlugin)
-addCommand(List("scripted"), "testPlugin", "Runs the scripted SBT plugin tests.")
+
+addCommand(
+  (ComposableCommand
+    .make(
+      "project zioSbtEcosystem"
+    ) >> "scripted" >> "project zioSbtWebsite" >> "scripted" >> "project root") ?? ("testPlugins", "Runs the scripted SBT plugin tests.")
+)
 
 inThisBuild(
   List(
@@ -59,7 +66,6 @@ lazy val zioSbtWebsite =
   project
     .in(file("zio-sbt-website"))
     .settings(buildInfoSettings("zio.sbt"))
-    .settings(addCommand(List("scripted"), "testPlugin", "Runs the scripted SBT plugin tests."))
     .settings(
       name               := "zio-sbt-website",
       headerEndYear      := Some(2023),
@@ -77,7 +83,6 @@ lazy val zioSbtEcosystem =
   project
     .in(file("zio-sbt-ecosystem"))
     .settings(buildInfoSettings("zio.sbt"))
-    .settings(addCommand(List("scripted"), "testPlugin", "Runs the scripted SBT plugin tests."))
     .settings(
       name               := "zio-sbt-ecosystem",
       headerEndYear      := Some(2023),

--- a/zio-sbt-ecosystem/src/main/scala/zio/sbt/V.scala
+++ b/zio-sbt-ecosystem/src/main/scala/zio/sbt/V.scala
@@ -21,9 +21,9 @@ trait Versions {
   object versions {
 
     val cassandraDriverVersion               = "4.14.1"
-    val scala213Version                      = "2.13.8"
-    val scala212Version                      = "2.12.16"
-    val scala3Version                        = "3.1.3"
+    val scala213Version                      = "2.13.10"
+    val scala212Version                      = "2.12.17"
+    val scala3Version                        = "3.2.1"
     val supportedScalaVersions: List[String] = List(scala213Version, scala212Version, scala3Version)
     val zio1xVersion                         = "1.0.15"
     val zio2xVersion                         = "2.0.4"
@@ -34,23 +34,33 @@ trait Versions {
       import java.util.{List => JList, Map => JMap}
       import scala.jdk.CollectionConverters._
 
-      val doc = new Load(LoadSettings.builder().build())
-        .loadFromReader(scala.io.Source.fromFile(".github/workflows/ci.yml").bufferedReader())
-      val yaml = doc.asInstanceOf[JMap[String, JMap[String, JMap[String, JMap[String, JMap[String, JList[String]]]]]]]
+      try {
+        val doc = new Load(LoadSettings.builder().build())
+          .loadFromReader(scala.io.Source.fromFile(".github/workflows/ci.yml").bufferedReader())
+        val yaml = doc.asInstanceOf[JMap[String, JMap[String, JMap[String, JMap[String, JMap[String, JList[String]]]]]]]
 
-      val list = yaml
-        .getOrDefault("jobs", Map.empty.asJava)
-        .getOrDefault("build", Map.empty.asJava)
-        .getOrDefault("strategy", Map.empty.asJava)
-        .getOrDefault("matrix", Map.empty.asJava)
-        .getOrDefault("scala", List.empty.asJava)
-        .asScala
-      list.map(v => (v.split('.').take(2).mkString("."), v)).toMap
+        val list = yaml
+          .getOrDefault("jobs", Map.empty.asJava)
+          .getOrDefault("build", Map.empty.asJava)
+          .getOrDefault("strategy", Map.empty.asJava)
+          .getOrDefault("matrix", Map.empty.asJava)
+          .getOrDefault("scala", List.empty.asJava)
+          .asScala
+
+        val m1 = list.filter(_.startsWith("2")).map(v => (v.split('.').take(2).mkString("."), v)).toMap
+        val m2 = list
+          .filter(_.startsWith("3"))
+          .map("3.x" -> _)
+          .toMap
+        m1 ++ m2
+      } catch {
+        case _: java.io.FileNotFoundException => Map.empty[String, String]
+      }
     }
 
     val Scala212: String = versions.getOrElse("2.12", scala212Version)
     val Scala213: String = versions.getOrElse("2.13", scala213Version)
-    val Scala3: String   = versions.getOrElse("3.1", scala3Version)
+    val Scala3: String   = versions.getOrElse("3.x", scala3Version)
   }
 }
 

--- a/zio-sbt-ecosystem/src/main/scala/zio/sbt/ZioEcosystemProjectPlugin.scala
+++ b/zio-sbt-ecosystem/src/main/scala/zio/sbt/ZioEcosystemProjectPlugin.scala
@@ -65,11 +65,14 @@ object ZioEcosystemProjectPlugin extends AutoPlugin {
 
     def addCommand(commandString: List[String], name: String, description: String): Seq[Setting[_]] = {
       val cCommand = Commands.ComposableCommand(commandString, name, description)
-      Seq(
-        commands += cCommand.toCommand,
-        usefulTasksAndSettings += cCommand.toItem
-      )
+      addCommand(cCommand)
     }
+
+    def addCommand(command: Commands.ComposableCommand): Seq[Setting[_]] =
+      Seq(
+        commands += command.toCommand,
+        usefulTasksAndSettings += command.toItem
+      )
 
     val zioSeries: SettingKey[ZIOSeries] = settingKey[ZIOSeries]("Indicates whether to use ZIO 2.x or ZIO 1.x.")
 

--- a/zio-sbt-ecosystem/src/sbt-test/zio-sbt-ecosystem/verifySettings/build.sbt
+++ b/zio-sbt-ecosystem/src/sbt-test/zio-sbt-ecosystem/verifySettings/build.sbt
@@ -1,0 +1,12 @@
+
+lazy val root = (project in file("."))
+  .settings(
+    version := "0.1",
+    TaskKey[Unit]("check") := {
+      Testing.eq("versions.Scala212", "2.12.17", versions.Scala212)
+      Testing.eq("versions.Scala213", "2.13.10", versions.Scala213)
+      Testing.eq("versions.Scala3", "3.2.1", versions.Scala3)
+      ()
+    }
+  )
+  .enablePlugins(ZioEcosystemProjectPlugin)

--- a/zio-sbt-ecosystem/src/sbt-test/zio-sbt-ecosystem/verifySettings/project/Testing.scala
+++ b/zio-sbt-ecosystem/src/sbt-test/zio-sbt-ecosystem/verifySettings/project/Testing.scala
@@ -1,0 +1,6 @@
+object Testing {
+
+  def eq[A](name: String, expected: A, actual: A): Unit =
+    if (expected != actual) sys.error(s"$name: expected $expected, but got $actual")
+
+}

--- a/zio-sbt-ecosystem/src/sbt-test/zio-sbt-ecosystem/verifySettings/project/plugins.sbt
+++ b/zio-sbt-ecosystem/src/sbt-test/zio-sbt-ecosystem/verifySettings/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("dev.zio" % "zio-sbt-ecosystem" % x)
+  case _       => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/zio-sbt-ecosystem/src/sbt-test/zio-sbt-ecosystem/verifySettings/src/main/scala/Main.scala
+++ b/zio-sbt-ecosystem/src/sbt-test/zio-sbt-ecosystem/verifySettings/src/main/scala/Main.scala
@@ -1,0 +1,3 @@
+object Main {
+  def main(args: Array[String]): Unit = println("hello, zio")
+}

--- a/zio-sbt-ecosystem/src/sbt-test/zio-sbt-ecosystem/verifySettings/test
+++ b/zio-sbt-ecosystem/src/sbt-test/zio-sbt-ecosystem/verifySettings/test
@@ -1,0 +1,3 @@
+> clean
+> compile
+> check 

--- a/zio-sbt-ecosystem/src/sbt-test/zio-sbt-ecosystem/verifySettingsWithCI/.github/workflows/ci.yml
+++ b/zio-sbt-ecosystem/src/sbt-test/zio-sbt-ecosystem/verifySettingsWithCI/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+env:
+  JDK_JAVA_OPTIONS: -XX:+PrintCommandLineFlags -Xmx6G -Xss4M -XX:+UseG1GC # JDK_JAVA_OPTIONS is _the_ env. variable to use for modern Java
+  JVM_OPTS: -XX:+PrintCommandLineFlags -Xmx6G -Xss4M -XX:+UseG1GC # for Java 8 only (sadly, it is not modern enough for JDK_JAVA_OPTIONS)
+  NODE_OPTIONS: --max_old_space_size=6144
+
+on:
+  pull_request:
+  push:
+    branches: ['main']
+  release:
+    types:
+      - published
+
+jobs:
+
+  build:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        java: ['adopt@1.8', 'adopt@1.11']
+        # These version must be different than the versions in V.scala to verify that we are reading from the ci.yml file.
+        scala: ['2.12.16', '2.13.9', '3.2.0' ]
+    steps:
+    - uses: actions/checkout@v3.2.0
+    - uses: olafurpg/setup-scala@v13
+      with:
+        java-version: ${{ matrix.java }}
+    - name: Cache scala dependencies
+      uses: coursier/cache-action@v6
+    - name: Run tests
+      run: sbt ++${{ matrix.scala }}! test
+          

--- a/zio-sbt-ecosystem/src/sbt-test/zio-sbt-ecosystem/verifySettingsWithCI/build.sbt
+++ b/zio-sbt-ecosystem/src/sbt-test/zio-sbt-ecosystem/verifySettingsWithCI/build.sbt
@@ -1,0 +1,13 @@
+
+lazy val root = (project in file("."))
+  .settings(
+    version := "0.1",
+    TaskKey[Unit]("check") := {
+      // These values must match the values in .github/workflows/ci.yml.
+      Testing.eq("versions.Scala212", "2.12.16", versions.Scala212)
+      Testing.eq("versions.Scala213", "2.13.9", versions.Scala213)
+      Testing.eq("versions.Scala3", "3.2.0", versions.Scala3)
+      ()
+    }
+  )
+  .enablePlugins(ZioEcosystemProjectPlugin)

--- a/zio-sbt-ecosystem/src/sbt-test/zio-sbt-ecosystem/verifySettingsWithCI/project/Testing.scala
+++ b/zio-sbt-ecosystem/src/sbt-test/zio-sbt-ecosystem/verifySettingsWithCI/project/Testing.scala
@@ -1,0 +1,6 @@
+object Testing {
+
+  def eq[A](name: String, expected: A, actual: A): Unit =
+    if (expected != actual) sys.error(s"$name: expected $expected, but got $actual")
+
+}

--- a/zio-sbt-ecosystem/src/sbt-test/zio-sbt-ecosystem/verifySettingsWithCI/project/plugins.sbt
+++ b/zio-sbt-ecosystem/src/sbt-test/zio-sbt-ecosystem/verifySettingsWithCI/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("dev.zio" % "zio-sbt-ecosystem" % x)
+  case _       => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/zio-sbt-ecosystem/src/sbt-test/zio-sbt-ecosystem/verifySettingsWithCI/src/main/scala/Main.scala
+++ b/zio-sbt-ecosystem/src/sbt-test/zio-sbt-ecosystem/verifySettingsWithCI/src/main/scala/Main.scala
@@ -1,0 +1,3 @@
+object Main {
+  def main(args: Array[String]): Unit = println("hello, zio")
+}

--- a/zio-sbt-ecosystem/src/sbt-test/zio-sbt-ecosystem/verifySettingsWithCI/test
+++ b/zio-sbt-ecosystem/src/sbt-test/zio-sbt-ecosystem/verifySettingsWithCI/test
@@ -1,0 +1,3 @@
+> clean
+> compile
+> check 

--- a/zio-sbt-website/src/main/scala/zio/sbt/WebsitePlugin.scala
+++ b/zio-sbt-website/src/main/scala/zio/sbt/WebsitePlugin.scala
@@ -20,6 +20,7 @@ import java.nio.file.{Path, Paths}
 
 import scala.sys.process.*
 
+import _root_.java.nio.file.Files
 import mdoc.MdocPlugin
 import mdoc.MdocPlugin.autoImport.*
 import sbt.Keys.*
@@ -165,7 +166,10 @@ object WebsitePlugin extends sbt.AutoPlugin {
     Def.task {
       val logger = streams.value.log
 
-      exit(Process(s"rm ${target.value}/${normalizedName.value}-website -Rvf").!)
+      val siteTarget = s"${target.value}/${normalizedName.value}-website"
+
+      if (Files.exists(Paths.get(siteTarget)))
+        exit(Process(s"rm $siteTarget -Rvf").!)
 
       val task: String =
         s"""|npx @zio.dev/create-zio-website@latest ${normalizedName.value}-website \\

--- a/zio-sbt-website/src/sbt-test/zio-sbt-website/compileDocs/build.sbt
+++ b/zio-sbt-website/src/sbt-test/zio-sbt-website/compileDocs/build.sbt
@@ -1,4 +1,7 @@
 lazy val root = (project in file("."))
   .settings(
     version := "0.1",
+    projectName := "ZIO SBT",
+    mainModuleName := "test-project",
+    projectStage   := ProjectStage.ProductionReady,
   ).enablePlugins(WebsitePlugin)

--- a/zio-sbt-website/src/sbt-test/zio-sbt-website/installWebsite/build.sbt
+++ b/zio-sbt-website/src/sbt-test/zio-sbt-website/installWebsite/build.sbt
@@ -1,4 +1,7 @@
 lazy val root = (project in file("."))
   .settings(
     version := "0.1",
+    projectName := "ZIO SBT",
+    mainModuleName := "test-project",
+    projectStage   := ProjectStage.ProductionReady,
   ).enablePlugins(WebsitePlugin)


### PR DESCRIPTION
Scala 3 is now keyed using '3.x' instead of '3.1'.

Additional housekeeping:
- All default versions of Scala brought current.
- Added Scripted tests for ecosystem plugin.
- Fixed broken scripted tests for website plugin.
- Fixed 'testPlugins' command to actually work correctly.
- Updated CI to run 'build' on all non-main pushes and  PRs.
- 'testPlugins' add to CI 'build' job.