### PR TITLE
Fix scalac `-encoding` flag value

### DIFF
--- a/zio-sbt-ecosystem/src/main/scala/zio/sbt/ScalaCompilerSettings.scala
+++ b/zio-sbt-ecosystem/src/main/scala/zio/sbt/ScalaCompilerSettings.scala
@@ -31,7 +31,7 @@ trait ScalaCompilerSettings {
   private val stdOptions = Seq(
     "-deprecation",
     "-encoding",
-    "UTF-8",
+    "utf8",
     "-feature",
     "-unchecked"
   )


### PR DESCRIPTION
See https://docs.scala-lang.org/overviews/compiler-options/index.html

The previous value was generating the following error:
```scala
[error] IO error while decoding UTF-8 with UTF-8: UTF-8 (No such file or directory)
[error] Please try specifying another one using the -encoding option
[error] one error found
```