### PR TITLE
Drop Java 8 support && Introduce Java21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Setup Scala
       uses: actions/setup-java@v3.13.0
       with:
-        distribution: temurin
+        distribution: corretto
         java-version: '17'
         check-latest: true
     - name: Cache Dependencies
@@ -54,7 +54,7 @@ jobs:
     - name: Setup Scala
       uses: actions/setup-java@v3.13.0
       with:
-        distribution: temurin
+        distribution: corretto
         java-version: '17'
         check-latest: true
     - name: Cache Dependencies
@@ -77,7 +77,7 @@ jobs:
     - name: Setup Scala
       uses: actions/setup-java@v3.13.0
       with:
-        distribution: temurin
+        distribution: corretto
         java-version: ${{ matrix.java }}
         check-latest: true
     - name: Cache Dependencies
@@ -103,7 +103,7 @@ jobs:
     - name: Setup Scala
       uses: actions/setup-java@v3.13.0
       with:
-        distribution: temurin
+        distribution: corretto
         java-version: '17'
         check-latest: true
     - name: Cache Dependencies
@@ -177,7 +177,7 @@ jobs:
     - name: Setup Scala
       uses: actions/setup-java@v3.13.0
       with:
-        distribution: temurin
+        distribution: corretto
         java-version: '17'
         check-latest: true
     - name: Cache Dependencies
@@ -206,7 +206,7 @@ jobs:
     - name: Setup Scala
       uses: actions/setup-java@v3.13.0
       with:
-        distribution: temurin
+        distribution: corretto
         java-version: '17'
         check-latest: true
     - name: Cache Dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@
 name: CI
 env:
   JDK_JAVA_OPTIONS: -XX:+PrintCommandLineFlags
-  JVM_OPTS: -XX:+PrintCommandLineFlags
 'on':
   workflow_dispatch: {}
   release:
@@ -70,7 +69,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: ['11', '17', '21']
+        java:
+        - '11'
+        - '17'
+        - '21'
     steps:
     - name: Install libuv
       run: sudo apt-get update && sudo apt-get install -y libuv1-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       uses: actions/setup-java@v3.13.0
       with:
         distribution: temurin
-        java-version: '8'
+        java-version: '17'
         check-latest: true
     - name: Cache Dependencies
       uses: coursier/cache-action@v6
@@ -55,7 +55,7 @@ jobs:
       uses: actions/setup-java@v3.13.0
       with:
         distribution: temurin
-        java-version: '8'
+        java-version: '17'
         check-latest: true
     - name: Cache Dependencies
       uses: coursier/cache-action@v6
@@ -70,10 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java:
-        - '8'
-        - '11'
-        - '17'
+        java: ['11', '17', '21']
     steps:
     - name: Install libuv
       run: sudo apt-get update && sudo apt-get install -y libuv1-dev
@@ -107,7 +104,7 @@ jobs:
       uses: actions/setup-java@v3.13.0
       with:
         distribution: temurin
-        java-version: '8'
+        java-version: '17'
         check-latest: true
     - name: Cache Dependencies
       uses: coursier/cache-action@v6
@@ -181,7 +178,7 @@ jobs:
       uses: actions/setup-java@v3.13.0
       with:
         distribution: temurin
-        java-version: '8'
+        java-version: '17'
         check-latest: true
     - name: Cache Dependencies
       uses: coursier/cache-action@v6
@@ -210,7 +207,7 @@ jobs:
       uses: actions/setup-java@v3.13.0
       with:
         distribution: temurin
-        java-version: '8'
+        java-version: '17'
         check-latest: true
     - name: Cache Dependencies
       uses: coursier/cache-action@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     continue-on-error: true
     steps:
     - name: Git Checkout
-      uses: actions/checkout@v4.0.0
+      uses: actions/checkout@v4.1.0
       with:
         fetch-depth: '0'
     - name: Install libuv
@@ -45,7 +45,7 @@ jobs:
     continue-on-error: false
     steps:
     - name: Git Checkout
-      uses: actions/checkout@v4.0.0
+      uses: actions/checkout@v4.1.0
       with:
         fetch-depth: '0'
     - name: Install libuv
@@ -85,7 +85,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v6
     - name: Git Checkout
-      uses: actions/checkout@v4.0.0
+      uses: actions/checkout@v4.1.0
       with:
         fetch-depth: '0'
     - name: Test
@@ -97,7 +97,7 @@ jobs:
     if: ${{ github.event_name == 'push' }}
     steps:
     - name: Git Checkout
-      uses: actions/checkout@v4.0.0
+      uses: actions/checkout@v4.1.0
       with:
         fetch-depth: '0'
     - name: Install libuv
@@ -171,7 +171,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
     steps:
     - name: Git Checkout
-      uses: actions/checkout@v4.0.0
+      uses: actions/checkout@v4.1.0
       with:
         fetch-depth: '0'
     - name: Install libuv
@@ -200,7 +200,7 @@ jobs:
     if: ${{ ((github.event_name == 'release') && (github.event.action == 'published')) || (github.event_name == 'workflow_dispatch') }}
     steps:
     - name: Git Checkout
-      uses: actions/checkout@v4.0.0
+      uses: actions/checkout@v4.1.0
       with:
         fetch-depth: '0'
     - name: Install libuv
@@ -231,7 +231,7 @@ jobs:
     if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
     steps:
     - name: Git Checkout
-      uses: actions/checkout@v4.0.0
+      uses: actions/checkout@v4.1.0
       with:
         fetch-depth: '0'
     - name: notify the main repo about the new release of docs package

--- a/README.md
+++ b/README.md
@@ -140,10 +140,7 @@ test:
   strategy:
     fail-fast: false
     matrix:
-      java:
-      - '8'
-      - '11'
-      - '17'
+      java: ['11', '17', '21']
   steps:
   - name: Install libuv
     run: sudo apt-get update && sudo apt-get install -y libuv1-dev
@@ -171,12 +168,12 @@ In some cases, we may have multiple submodules in our project and we want to tes
 
 The `ciTargetScalaVersions` setting key is used to define a mapping of project names to the Scala versions that should be used for testing phase of continuous integration (CI).
 
-For example, suppose we have a project with the name "submoduleA" and we want to test it against Scala `2.12.18`, and for the "submoduleB" we want to test it against Scala `2.12.18` and `2.13.11` and `3.3.0`, We can define the `ciTargetScalaVersions` setting as follows:
+For example, suppose we have a project with the name "submoduleA" and we want to test it against Scala `2.12.18`, and for the "submoduleB" we want to test it against Scala `2.12.18` and `2.13.12` and `3.3.1`, We can define the `ciTargetScalaVersions` setting as follows:
 
 ```scala
 ThisBuild / ciTargetScalaVersions := Map(
     "submoduleA" -> Seq("2.12.18"),
-    "submoduleB" -> Seq("2.12.18", "2.13.11", "3.3.0")
+    "submoduleB" -> Seq("2.12.18", "2.13.12", "3.3.1")
   )
 ```
 
@@ -207,15 +204,12 @@ test:
   strategy:
     fail-fast: false
     matrix:
-      java:
-      - '8'
-      - '11'
-      - '17'
+      java: ['11', '17', '21']
       scala-project:
       - ++2.12.18 submoduleA
       - ++2.12.18 submoduleB
-      - ++2.13.11 submoduleB
-      - ++3.3.0 submoduleB
+      - ++2.13.12 submoduleB
+      - ++3.3.1 submoduleB
   steps:
   - name: Install libuv
     run: sudo apt-get update && sudo apt-get install -y libuv1-dev

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ test:
   - name: Setup Scala
     uses: actions/setup-java@v3.12.0
     with:
-      distribution: temurin
+      distribution: corretto
       java-version: ${{ matrix.java }}
       check-latest: true
   - name: Cache Dependencies
@@ -216,7 +216,7 @@ test:
   - name: Setup Scala
     uses: actions/setup-java@v3.10.0
     with:
-      distribution: temurin
+      distribution: corretto
       java-version: ${{ matrix.java }}
       check-latest: true
   - name: Cache Dependencies

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ test:
   - name: Cache Dependencies
     uses: coursier/cache-action@v6
   - name: Git Checkout
-    uses: actions/checkout@v4.0.0
+    uses: actions/checkout@v4.1.0
     with:
       fetch-depth: '0'
   - name: Test
@@ -222,7 +222,7 @@ test:
   - name: Cache Dependencies
     uses: coursier/cache-action@v6
   - name: Git Checkout
-    uses: actions/checkout@v4.0.0
+    uses: actions/checkout@v4.1.0
     with:
       fetch-depth: '0'
   - name: Test

--- a/docs/index.md
+++ b/docs/index.md
@@ -145,7 +145,7 @@ test:
   - name: Setup Scala
     uses: actions/setup-java@v3.12.0
     with:
-      distribution: temurin
+      distribution: corretto
       java-version: ${{ matrix.java }}
       check-latest: true
   - name: Cache Dependencies
@@ -214,7 +214,7 @@ test:
   - name: Setup Scala
     uses: actions/setup-java@v3.10.0
     with:
-      distribution: temurin
+      distribution: corretto
       java-version: ${{ matrix.java }}
       check-latest: true
   - name: Cache Dependencies

--- a/docs/index.md
+++ b/docs/index.md
@@ -151,7 +151,7 @@ test:
   - name: Cache Dependencies
     uses: coursier/cache-action@v6
   - name: Git Checkout
-    uses: actions/checkout@v4.0.0
+    uses: actions/checkout@v4.1.0
     with:
       fetch-depth: '0'
   - name: Test
@@ -220,7 +220,7 @@ test:
   - name: Cache Dependencies
     uses: coursier/cache-action@v6
   - name: Git Checkout
-    uses: actions/checkout@v4.0.0
+    uses: actions/checkout@v4.1.0
     with:
       fetch-depth: '0'
   - name: Test

--- a/docs/index.md
+++ b/docs/index.md
@@ -138,11 +138,7 @@ test:
   continue-on-error: false
   strategy:
     fail-fast: false
-    matrix:
-      java:
-      - '8'
-      - '11'
-      - '17'
+    java: ['11', '17', '21']
   steps:
   - name: Install libuv
     run: sudo apt-get update && sudo apt-get install -y libuv1-dev
@@ -170,12 +166,12 @@ In some cases, we may have multiple submodules in our project and we want to tes
 
 The `ciTargetScalaVersions` setting key is used to define a mapping of project names to the Scala versions that should be used for testing phase of continuous integration (CI).
 
-For example, suppose we have a project with the name "submoduleA" and we want to test it against Scala `2.12.18`, and for the "submoduleB" we want to test it against Scala `2.12.18` and `2.13.11` and `3.3.0`, We can define the `ciTargetScalaVersions` setting as follows:
+For example, suppose we have a project with the name "submoduleA" and we want to test it against Scala `2.12.18`, and for the "submoduleB" we want to test it against Scala `2.12.18` and `2.13.12` and `3.3.1`, We can define the `ciTargetScalaVersions` setting as follows:
 
 ```scala
 ThisBuild / ciTargetScalaVersions := Map(
     "submoduleA" -> Seq("2.12.18"),
-    "submoduleB" -> Seq("2.12.18", "2.13.11", "3.3.0")
+    "submoduleB" -> Seq("2.12.18", "2.13.12", "3.3.1")
   )
 ```
 
@@ -206,15 +202,12 @@ test:
   strategy:
     fail-fast: false
     matrix:
-      java:
-      - '8'
-      - '11'
-      - '17'
+      java: ['11', '17', '21']
       scala-project:
       - ++2.12.18 submoduleA
       - ++2.12.18 submoduleB
-      - ++2.13.11 submoduleB
-      - ++3.3.0 submoduleB
+      - ++2.13.12 submoduleB
+      - ++3.3.1 submoduleB
   steps:
   - name: Install libuv
     run: sudo apt-get update && sudo apt-get install -y libuv1-dev

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,6 +1,6 @@
 object Versions {
   val Scala212 = "2.12.18"
-  val Scala213 = "2.13.11"
-  val Scala3   = "3.3.0"
-  val zio      = "2.0.16"
+  val Scala213 = "2.13.12"
+  val Scala3   = "3.3.1"
+  val zio      = "2.0.17"
 }

--- a/zio-sbt-ci/src/main/scala/zio/sbt/V.scala
+++ b/zio-sbt-ci/src/main/scala/zio/sbt/V.scala
@@ -6,7 +6,7 @@ object V {
       "peter-evans/create-pull-request" -> "v5.0.2",
       "zio/generate-github-app-token"   -> "v1.0.0",
       "pierotofy/set-swap-space"        -> "master",
-      "actions/checkout"                -> "v4.0.0",
+      "actions/checkout"                -> "v4.1.0",
       "actions/setup-java"              -> "v3.13.0",
       "coursier/cache-action"           -> "v6",
       "actions/setup-node"              -> "v3"

--- a/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
+++ b/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
@@ -521,7 +521,7 @@ object ZioSbtCiPlugin extends AutoPlugin {
       val nodeOptions      = ciNodeOptions.value
 
       val jvmMap = Map(
-        "JDK_JAVA_OPTIONS" -> jvmOptions.mkString(" "),
+        "JDK_JAVA_OPTIONS" -> jvmOptions.mkString(" ")
       )
       val nodeMap: Map[String, String] =
         if (nodeOptions.nonEmpty) Map("NODE_OPTIONS" -> nodeOptions.mkString(" ")) else Map.empty

--- a/zio-sbt-ecosystem/src/main/scala/zio/sbt/ScalaCompilerSettings.scala
+++ b/zio-sbt-ecosystem/src/main/scala/zio/sbt/ScalaCompilerSettings.scala
@@ -158,7 +158,7 @@ trait ScalaCompilerSettings {
   def stdSettings(
     name: Option[String] = None,
     packageName: Option[String] = None,
-    javaPlatform: String = "8",
+    javaPlatform: String = "11",
     enableKindProjector: Boolean = true,
     enableCrossProject: Boolean = false,
     enableScalafix: Boolean = true,

--- a/zio-sbt-ecosystem/src/main/scala/zio/sbt/Versions.scala
+++ b/zio-sbt-ecosystem/src/main/scala/zio/sbt/Versions.scala
@@ -22,11 +22,11 @@ object Versions {
   val KindProjectorVersion = "0.13.2"
   val ScaluzziVersion      = "0.1.23"
 
-  val scala3   = "3.3.0"
+  val scala3   = "3.3.1"
   val scala212 = "2.12.18"
-  val scala213 = "2.13.11"
+  val scala213 = "2.13.12"
 
-  val zioVersion = "2.0.16"
+  val zioVersion = "2.0.17"
 
   lazy val betterMonadFor: ModuleID = "com.olegpy" %% "better-monadic-for" % "0.3.1"
 }

--- a/zio-sbt-ecosystem/src/sbt-test/zio-sbt-ecosystem/verifySettingsWithCI/.github/workflows/ci.yml
+++ b/zio-sbt-ecosystem/src/sbt-test/zio-sbt-ecosystem/verifySettingsWithCI/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/checkout@v4.0.0
     - uses: actions/setup-java@v3.12.0
       with:
-        distribution: temurin
+        distribution: corretto
         java-version: ${{ matrix.java }}
         check-latest: true
     - name: Cache scala dependencies

--- a/zio-sbt-ecosystem/src/sbt-test/zio-sbt-ecosystem/verifySettingsWithCI/.github/workflows/ci.yml
+++ b/zio-sbt-ecosystem/src/sbt-test/zio-sbt-ecosystem/verifySettingsWithCI/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 env:
   JDK_JAVA_OPTIONS: -XX:+PrintCommandLineFlags -Xmx6G -Xss4M -XX:+UseG1GC # JDK_JAVA_OPTIONS is _the_ env. variable to use for modern Java
-  JVM_OPTS: -XX:+PrintCommandLineFlags -Xmx6G -Xss4M -XX:+UseG1GC # for Java 8 only (sadly, it is not modern enough for JDK_JAVA_OPTIONS)
   NODE_OPTIONS: --max_old_space_size=6144
 
 on:
@@ -21,9 +20,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: ['8', '11', '17']
+        java: ['11', '17', '21']
         # These version must be different than the versions in V.scala to verify that we are reading from the ci.yml file.
-        scala: ['2.12.18', '2.13.11', '3.3.0' ]
+        scala: ['2.12.18', '2.13.12', '3.3.1' ]
     steps:
     - uses: actions/checkout@v4.0.0
     - uses: actions/setup-java@v3.12.0

--- a/zio-sbt-ecosystem/src/sbt-test/zio-sbt-ecosystem/verifySettingsWithCI/.github/workflows/ci.yml
+++ b/zio-sbt-ecosystem/src/sbt-test/zio-sbt-ecosystem/verifySettingsWithCI/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         # These version must be different than the versions in V.scala to verify that we are reading from the ci.yml file.
         scala: ['2.12.18', '2.13.12', '3.3.1' ]
     steps:
-    - uses: actions/checkout@v4.0.0
+    - uses: actions/checkout@v4.1.0
     - uses: actions/setup-java@v3.12.0
       with:
         distribution: corretto


### PR DESCRIPTION
Follows https://github.com/zio/zio/pull/8434

⚠️ This PR changes the version of the Java bytecode emitted. 
We were emitting Java8 bytecode, not we generate Java11 bytecode.
See https://github.com/zio/zio-sbt/pull/296/files#diff-bf3171487bdb6bd0654f0cdda719dffd49d5f9f7aabd2bfacdfc5f20588ddea9R161

Asked the question to @jdegoes and @adamgfraser if they were okay with this change here: https://x.com/guizmaii/status/1705963927710941321?s=20
Waiting for answer 🙂