### PR TITLE
Prevent concurrent builds on branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ env:
   pull_request:
     branches-ignore:
     - gh-pages
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.run_id || github.ref }}
+  cancel-in-progress: true
 jobs:
   build:
     name: Build

--- a/zio-sbt-githubactions/src/main/scala/zio/sbt/githubactions/model.scala
+++ b/zio-sbt-githubactions/src/main/scala/zio/sbt/githubactions/model.scala
@@ -316,6 +316,12 @@ object Workflow {
                          .map(_.toKeyValuePair): _*
                      )
                    }),
+          "concurrency" := Json.obj(
+            "group" := Json.fromString(
+              "${{ github.workflow }}-${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.run_id || github.ref }}"
+            ),
+            "cancel-in-progress" := true
+          ),
           "jobs" := Json.obj(wf.jobs.map(job => job.id := job): _*)
         )
 }


### PR DESCRIPTION
Prevent multiple builds at the same time from the same branch by cancelling the earlier builds. The default branch (e.g. master) is exempted, that is, builds from the default branch may run concurrently.