### PR TITLE
Report dependencies to GitHub

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -1,0 +1,13 @@
+name: Update Dependency Graph
+on:
+  push:
+    branches:
+      - main
+jobs:
+  dependency-graph:
+    name: Update Dependency Graph
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: sbt/setup-sbt@v1
+      - uses: scalacenter/sbt-dependency-submission@v2


### PR DESCRIPTION
Add a workflow for reporting the dependencies to GitHub, allowing security warnings from GitHub.

As described on https://github.com/marketplace/actions/sbt-dependency-submission, before running the workflow, make sure that the `Dependency Graph` feature is enabled in the settings of your repository (`Settings` > `Code Security and Analysis`). 
The graph of your sbt build will be visible in the [Dependency Graph](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/exploring-the-dependencies-of-a-repository) page of the `Insights` tab.