### PR TITLE
 Run update readme on every commit to default branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
     name: Update README
     runs-on: ubuntu-latest
     continue-on-error: false
-    if: ${{ github.event_name == 'push' }}
+    if: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
     steps:
     - name: Git Checkout
       uses: actions/checkout@v5

--- a/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
+++ b/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
@@ -355,7 +355,9 @@ object ZioSbtCiPlugin extends AutoPlugin {
       Job(
         id = "update-readme",
         name = "Update README",
-        condition = updateReadmeCondition orElse Some(Condition.Expression("github.event_name == 'push'")),
+        condition = updateReadmeCondition orElse Some(
+          Condition.Expression("github.ref == format('refs/heads/{0}', github.event.repository.default_branch)")
+        ),
         steps = (if (swapSizeGB > 0) Seq(setSwapSpace) else Seq.empty) ++
           Seq(
             checkout,


### PR DESCRIPTION
The update-readme step doesn't run after a release. This is annoying as it causes the landing page to show the wrong version number. The step only runs in the _next_ pull request. For zio-kafka this is a small problem, but for zio-streams-compress this can take many weeks and is not nice at all.

With this change the default if condition for the update-readme step changes to `github.ref == format('refs/heads/{0}', github.event.repository.default_branch)` so that the step will run on every commit to the default branch (usually main or master).