### PR TITLE
Run Release step only on 'release' event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,7 @@ jobs:
     continue-on-error: false
     needs:
     - ci
-    if: ${{ github.event_name == 'release' }}
+    if: ${{ (github.event_name == 'release' || (github.event_name == 'workflow_dispatch')) }}
     steps:
     - name: Git Checkout
       uses: actions/checkout@v5

--- a/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
+++ b/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
@@ -437,7 +437,11 @@ object ZioSbtCiPlugin extends AutoPlugin {
         id = "release",
         name = "Release",
         need = jobs,
-        condition = Some(Condition.Expression("github.event_name == 'release'")),
+        condition = Some(
+          Condition.Expression("github.event_name == 'release'") || Condition.Expression(
+            "github.event_name == 'workflow_dispatch'"
+          )
+        ),
         steps = (if (swapSizeGB > 0) Seq(setSwapSpace) else Seq.empty) ++
           Seq(
             checkout,


### PR DESCRIPTION
Prevent conflict when sbt-ci-release runs concurrently on two actions and artifacts are published successfully by 'push' action, causing subsequent failure for 'release' action