### PR TITLE
Same condition for release steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
     continue-on-error: false
     needs:
     - ci
-    if: ${{ github.event_name != 'pull_request' }}
+    if: ${{ ((github.event_name == 'release') && (github.event.action == 'published')) || (github.event_name == 'workflow_dispatch') }}
     steps:
     - name: Git Checkout
       uses: actions/checkout@v6
@@ -246,7 +246,7 @@ jobs:
     continue-on-error: false
     needs:
     - release-docs
-    if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
+    if: ${{ ((github.event_name == 'release') && (github.event.action == 'published')) || (github.event_name == 'workflow_dispatch') }}
     steps:
     - name: Git Checkout
       uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ Before you submit a PR, make sure your tests are passing, and that the code is p
 ```
 sbt prepare
 
-sbt testPlugin
+sbt +test
 ```
 
 ## Code of Conduct

--- a/build.sbt
+++ b/build.sbt
@@ -147,7 +147,7 @@ lazy val docs = project
          |```
          |sbt prepare
          |
-         |sbt testPlugin
+         |sbt +test
          |```
          |""".stripMargin
   )

--- a/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
+++ b/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
@@ -426,6 +426,13 @@ object ZioSbtCiPlugin extends AutoPlugin {
     )
   }
 
+  private val releaseCondition = Some(
+    Condition.Expression("github.event_name == 'release'") &&
+      Condition.Expression("github.event.action == 'published'") || Condition.Expression(
+        "github.event_name == 'workflow_dispatch'"
+      )
+  )
+
   lazy val releaseJobs: Def.Initialize[Seq[Job]] = Def.setting {
     val swapSizeGB   = ciSwapSizeGB.value
     val setSwapSpace = SetSwapSpace.value
@@ -439,7 +446,7 @@ object ZioSbtCiPlugin extends AutoPlugin {
         id = "release",
         name = "Release",
         need = jobs,
-        condition = Some(Condition.Expression("github.event_name != 'pull_request'")),
+        condition = releaseCondition,
         steps = (if (swapSizeGB > 0) Seq(setSwapSpace) else Seq.empty) ++
           Seq(
             checkout,
@@ -465,12 +472,7 @@ object ZioSbtCiPlugin extends AutoPlugin {
         id = "release-docs",
         name = "Release Docs",
         need = Seq("release"),
-        condition = Some(
-          Condition.Expression("github.event_name == 'release'") &&
-            Condition.Expression("github.event.action == 'published'") || Condition.Expression(
-              "github.event_name == 'workflow_dispatch'"
-            )
-        ),
+        condition = releaseCondition,
         steps = (if (swapSizeGB > 0) Seq(setSwapSpace) else Seq.empty) ++
           Seq(
             Step.StepSequence(
@@ -490,10 +492,7 @@ object ZioSbtCiPlugin extends AutoPlugin {
         id = "notify-docs-release",
         name = "Notify Docs Release",
         need = Seq("release-docs"),
-        condition = Some(
-          Condition.Expression("github.event_name == 'release'") &&
-            Condition.Expression("github.event.action == 'published'")
-        ),
+        condition = releaseCondition,
         steps = Seq(
           checkout,
           SingleStep(


### PR DESCRIPTION
Based on https://github.com/zio/zio-streams-compress/pull/202 from @khajavi, use the same condition for all release steps in ci.yaml.

This change prevents a build from the main branch to stage release artifacts to sonatype. These staged artifacts would then later cause a conflict with artifacts staged from a release build.

Tested in zio-streams-compress:
- https://github.com/zio/zio-streams-compress/pull/204
- https://github.com/zio/zio-streams-compress/actions/runs/26325561046

Also:
- bring readme up to date