### PR TITLE
Add SourceFile utility and EmbedSourceModifier for mdoc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -104,9 +104,9 @@ lazy val `zio-sbt-source` =
         if (scalaBinaryVersion.value == "2.13") Seq("-Wunused:imports") else Seq()
       },
       libraryDependencies ++= Seq(
-        "org.scalameta" %% "mdoc" % "2.5.4",
-        "dev.zio" %% "zio-test" % zio % Test,
-        "dev.zio" %% "zio-test-sbt" % zio % Test,
+        "org.scalameta" %% "mdoc"         % "2.5.4",
+        "dev.zio"       %% "zio-test"     % zio % Test,
+        "dev.zio"       %% "zio-test-sbt" % zio % Test
       ) ++ {
         if (scalaBinaryVersion.value == "2.13") Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value)
         else Seq()

--- a/build.sbt
+++ b/build.sbt
@@ -104,8 +104,9 @@ lazy val `zio-sbt-source` =
         if (scalaBinaryVersion.value == "2.13") Seq("-Wunused:imports") else Seq()
       },
       libraryDependencies ++= Seq(
-        "dev.zio" %% "zio-test"     % zio % Test,
-        "dev.zio" %% "zio-test-sbt" % zio % Test
+        "org.scalameta" %% "mdoc"        % "2.5.4",
+        "dev.zio"       %% "zio-test"    % zio % Test,
+        "dev.zio"       %% "zio-test-sbt" % zio % Test
       ) ++ {
         if (scalaBinaryVersion.value == "2.13") Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value)
         else Seq()

--- a/build.sbt
+++ b/build.sbt
@@ -104,9 +104,9 @@ lazy val `zio-sbt-source` =
         if (scalaBinaryVersion.value == "2.13") Seq("-Wunused:imports") else Seq()
       },
       libraryDependencies ++= Seq(
-        "org.scalameta" %% "mdoc"        % "2.5.4",
-        "dev.zio"       %% "zio-test"    % zio % Test,
-        "dev.zio"       %% "zio-test-sbt" % zio % Test
+        "org.scalameta" %% "mdoc" % "2.5.4",
+        "dev.zio" %% "zio-test" % zio % Test,
+        "dev.zio" %% "zio-test-sbt" % zio % Test,
       ) ++ {
         if (scalaBinaryVersion.value == "2.13") Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value)
         else Seq()

--- a/zio-sbt-source/src/main/resources/META-INF/services/mdoc.PostModifier
+++ b/zio-sbt-source/src/main/resources/META-INF/services/mdoc.PostModifier
@@ -1,0 +1,1 @@
+zio.sbt.EmbedSourceModifier

--- a/zio-sbt-source/src/main/scala/zio/sbt/EmbedSourceModifier.scala
+++ b/zio-sbt-source/src/main/scala/zio/sbt/EmbedSourceModifier.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.sbt
+
+import java.io.{ByteArrayOutputStream, PrintStream}
+
+import mdoc.PostModifier
+import mdoc.PostModifierContext
+
+class EmbedSourceModifier extends PostModifier {
+  override val name = "embed"
+
+  override def process(ctx: PostModifierContext): String = {
+    val parts = ctx.info.split(":")
+    val path  = if (parts.length > 1) parts(1) else ""
+
+    if (path.isEmpty) {
+      ctx.reporter.error(
+        s"embed modifier requires a path argument: ```scala mdoc:embed:path/to/file.scala"
+      )
+      return ""
+    }
+
+    val baos = new ByteArrayOutputStream()
+    val ps   = new PrintStream(baos)
+    try {
+      Console.withOut(ps) {
+        SourceFile.printSource(path)
+      }
+      ps.flush()
+      baos.toString("UTF-8")
+    } catch {
+      case e: Exception =>
+        ctx.reporter.error(s"Failed to embed source from '$path': ${e.getMessage}")
+        ""
+    }
+  }
+}

--- a/zio-sbt-source/src/main/scala/zio/sbt/EmbedSourceModifier.scala
+++ b/zio-sbt-source/src/main/scala/zio/sbt/EmbedSourceModifier.scala
@@ -19,8 +19,10 @@ package zio.sbt
 import java.io.{ByteArrayOutputStream, PrintStream}
 import java.nio.charset.StandardCharsets
 
-import mdoc.PostModifier
-import mdoc.PostModifierContext
+import mdoc.{
+  PostModifier,
+  PostModifierContext
+}
 
 class EmbedSourceModifier extends PostModifier {
   override val name = "embed"

--- a/zio-sbt-source/src/main/scala/zio/sbt/EmbedSourceModifier.scala
+++ b/zio-sbt-source/src/main/scala/zio/sbt/EmbedSourceModifier.scala
@@ -17,6 +17,7 @@
 package zio.sbt
 
 import java.io.{ByteArrayOutputStream, PrintStream}
+import java.nio.charset.StandardCharsets
 
 import mdoc.PostModifier
 import mdoc.PostModifierContext
@@ -25,12 +26,11 @@ class EmbedSourceModifier extends PostModifier {
   override val name = "embed"
 
   override def process(ctx: PostModifierContext): String = {
-    val parts = ctx.info.split(":")
-    val path  = if (parts.length > 1) parts(1) else ""
+    val path = ctx.info.stripPrefix("embed:").stripPrefix(":")
 
     if (path.isEmpty) {
       ctx.reporter.error(
-        s"embed modifier requires a path argument: ```scala mdoc:embed:path/to/file.scala"
+        "embed modifier requires a path argument: mdoc:embed:path/to/file.scala"
       )
       return ""
     }
@@ -42,7 +42,7 @@ class EmbedSourceModifier extends PostModifier {
         SourceFile.printSource(path)
       }
       ps.flush()
-      baos.toString("UTF-8")
+      baos.toString(StandardCharsets.UTF_8.name())
     } catch {
       case e: Exception =>
         ctx.reporter.error(s"Failed to embed source from '$path': ${e.getMessage}")

--- a/zio-sbt-source/src/main/scala/zio/sbt/EmbedSourceModifier.scala
+++ b/zio-sbt-source/src/main/scala/zio/sbt/EmbedSourceModifier.scala
@@ -19,10 +19,7 @@ package zio.sbt
 import java.io.{ByteArrayOutputStream, PrintStream}
 import java.nio.charset.StandardCharsets
 
-import mdoc.{
-  PostModifier,
-  PostModifierContext
-}
+import mdoc.{PostModifier, PostModifierContext}
 
 class EmbedSourceModifier extends PostModifier {
   override val name = "embed"

--- a/zio-sbt-source/src/main/scala/zio/sbt/SourceFile.scala
+++ b/zio-sbt-source/src/main/scala/zio/sbt/SourceFile.scala
@@ -17,6 +17,7 @@
 package zio.sbt
 
 import java.io.{File => JFile}
+import java.nio.charset.StandardCharsets
 import java.nio.file.Paths
 
 import scala.io.Source
@@ -26,13 +27,16 @@ object SourceFile {
   def readSource(path: String): String = {
     val f          = new JFile(path)
     val actualPath = if (f.exists()) path else "../" + path
-    val src        = Source.fromFile(actualPath)
+    val src        = Source.fromFile(actualPath, StandardCharsets.UTF_8.name())
     try src.getLines().mkString("\n")
     finally src.close()
   }
 
-  def fileExtension(path: String): String =
-    Paths.get(path).getFileName.toString.split('.').lastOption.getOrElse("")
+  def fileExtension(path: String): String = {
+    val fileName = Paths.get(path).getFileName
+    if (fileName == null) ""
+    else fileName.toString.split('.').lastOption.getOrElse("")
+  }
 
   def printSource(
     path: String,

--- a/zio-sbt-source/src/main/scala/zio/sbt/SourceFile.scala
+++ b/zio-sbt-source/src/main/scala/zio/sbt/SourceFile.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.sbt
+
+import java.io.{File => JFile}
+import java.nio.file.Paths
+
+import scala.io.Source
+
+object SourceFile {
+
+  def readSource(path: String): String = {
+    val f          = new JFile(path)
+    val actualPath = if (f.exists()) path else "../" + path
+    val src        = Source.fromFile(actualPath)
+    try src.getLines().mkString("\n")
+    finally src.close()
+  }
+
+  def fileExtension(path: String): String =
+    Paths.get(path).getFileName.toString.split('.').lastOption.getOrElse("")
+
+  def printSource(
+    path: String,
+    comment: Boolean = true,
+    showLineNumbers: Boolean = false,
+  ): Unit = {
+    val title     = if (comment) s"""title="$path"""" else ""
+    val showLines = if (showLineNumbers) "showLineNumbers" else ""
+    val header    = Seq(s"```${fileExtension(path)}", title, showLines).filter(_.nonEmpty).mkString(" ")
+    println(header)
+    println(readSource(path))
+    println("```")
+  }
+}

--- a/zio-sbt-source/src/main/scala/zio/sbt/SourceFile.scala
+++ b/zio-sbt-source/src/main/scala/zio/sbt/SourceFile.scala
@@ -41,7 +41,7 @@ object SourceFile {
   def printSource(
     path: String,
     comment: Boolean = true,
-    showLineNumbers: Boolean = false,
+    showLineNumbers: Boolean = false
   ): Unit = {
     val title     = if (comment) s"""title="$path"""" else ""
     val showLines = if (showLineNumbers) "showLineNumbers" else ""

--- a/zio-sbt-source/src/test/scala/zio/sbt/SourceFileSpec.scala
+++ b/zio-sbt-source/src/test/scala/zio/sbt/SourceFileSpec.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2024-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.sbt
+
+import java.io.{ByteArrayOutputStream, PrintStream}
+import java.nio.file.Files
+
+import zio.Scope
+import zio.test._
+
+object SourceFileSpec extends ZIOSpecDefault {
+
+  // Evaluate result eagerly before finally-delete runs; mirrors SourceReaderSpec pattern.
+  private def withTempFile[A](content: String)(f: String => A): A = {
+    val tmp = Files.createTempFile("source_file_spec_", ".scala")
+    try {
+      Files.write(tmp, content.getBytes("UTF-8"))
+      f(tmp.toAbsolutePath.toString)
+    } finally {
+      Files.delete(tmp)
+    }
+  }
+
+  private def capture(block: => Unit): String = {
+    val baos = new ByteArrayOutputStream()
+    val ps   = new PrintStream(baos)
+    Console.withOut(ps)(block)
+    ps.flush()
+    baos.toString("UTF-8")
+  }
+
+  def spec: Spec[Environment with TestEnvironment with Scope, Any] =
+    suite("SourceFileSpec")(
+      suite("fileExtension")(
+        test("extracts scala extension") {
+          assertTrue(SourceFile.fileExtension("foo/bar/Baz.scala") == "scala")
+        },
+        test("extracts ts extension") {
+          assertTrue(SourceFile.fileExtension("src/index.ts") == "ts")
+        },
+        test("no extension returns full filename") {
+          assertTrue(SourceFile.fileExtension("Makefile") == "Makefile")
+        },
+      ),
+      suite("readSource")(
+        test("reads full file content") {
+          val result = withTempFile("line1\nline2\nline3")(SourceFile.readSource)
+          assertTrue(result == "line1\nline2\nline3")
+        },
+        test("reads single-line file") {
+          val result = withTempFile("only line")(SourceFile.readSource)
+          assertTrue(result == "only line")
+        },
+      ),
+      suite("printSource")(
+        test("default: includes title, no showLineNumbers") {
+          val (path, out) = withTempFile("val x = 1") { p =>
+            (p, capture(SourceFile.printSource(p)))
+          }
+          assertTrue(
+            out.startsWith(s"""```scala title="$path""""),
+            out.contains("val x = 1"),
+            out.trim.endsWith("```"),
+            !out.contains("showLineNumbers"),
+          )
+        },
+        test("comment=false omits title") {
+          val out = withTempFile("val x = 1") { p =>
+            capture(SourceFile.printSource(p, comment = false))
+          }
+          assertTrue(
+            out.startsWith("```scala\n"),
+            !out.contains("title="),
+          )
+        },
+        test("showLineNumbers=true adds showLineNumbers") {
+          val out = withTempFile("val x = 1") { p =>
+            capture(SourceFile.printSource(p, showLineNumbers = true))
+          }
+          assertTrue(out.contains("showLineNumbers"))
+        },
+        test("fenced block uses correct language tag from extension") {
+          val tmp = Files.createTempFile("source_file_spec_", ".ts")
+          try {
+            Files.write(tmp, "const x = 1;".getBytes("UTF-8"))
+            val out = capture(SourceFile.printSource(tmp.toAbsolutePath.toString, comment = false))
+            assertTrue(out.startsWith("```ts\n"))
+          } finally {
+            Files.delete(tmp)
+          }
+        },
+      ),
+    )
+}

--- a/zio-sbt-source/src/test/scala/zio/sbt/SourceFileSpec.scala
+++ b/zio-sbt-source/src/test/scala/zio/sbt/SourceFileSpec.scala
@@ -17,6 +17,7 @@
 package zio.sbt
 
 import java.io.{ByteArrayOutputStream, PrintStream}
+import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 
 import zio.Scope
@@ -28,7 +29,7 @@ object SourceFileSpec extends ZIOSpecDefault {
   private def withTempFile[A](content: String)(f: String => A): A = {
     val tmp = Files.createTempFile("source_file_spec_", ".scala")
     try {
-      Files.write(tmp, content.getBytes("UTF-8"))
+      Files.write(tmp, content.getBytes(StandardCharsets.UTF_8))
       f(tmp.toAbsolutePath.toString)
     } finally {
       Files.delete(tmp)
@@ -40,7 +41,7 @@ object SourceFileSpec extends ZIOSpecDefault {
     val ps   = new PrintStream(baos)
     Console.withOut(ps)(block)
     ps.flush()
-    baos.toString("UTF-8")
+    baos.toString(StandardCharsets.UTF_8.name())
   }
 
   def spec: Spec[Environment with TestEnvironment with Scope, Any] =
@@ -96,7 +97,7 @@ object SourceFileSpec extends ZIOSpecDefault {
         test("fenced block uses correct language tag from extension") {
           val tmp = Files.createTempFile("source_file_spec_", ".ts")
           try {
-            Files.write(tmp, "const x = 1;".getBytes("UTF-8"))
+            Files.write(tmp, "const x = 1;".getBytes(StandardCharsets.UTF_8))
             val out = capture(SourceFile.printSource(tmp.toAbsolutePath.toString, comment = false))
             assertTrue(out.startsWith("```ts\n"))
           } finally {

--- a/zio-sbt-source/src/test/scala/zio/sbt/SourceFileSpec.scala
+++ b/zio-sbt-source/src/test/scala/zio/sbt/SourceFileSpec.scala
@@ -55,7 +55,7 @@ object SourceFileSpec extends ZIOSpecDefault {
         },
         test("no extension returns full filename") {
           assertTrue(SourceFile.fileExtension("Makefile") == "Makefile")
-        },
+        }
       ),
       suite("readSource")(
         test("reads full file content") {
@@ -65,7 +65,7 @@ object SourceFileSpec extends ZIOSpecDefault {
         test("reads single-line file") {
           val result = withTempFile("only line")(SourceFile.readSource)
           assertTrue(result == "only line")
-        },
+        }
       ),
       suite("printSource")(
         test("default: includes title, no showLineNumbers") {
@@ -76,7 +76,7 @@ object SourceFileSpec extends ZIOSpecDefault {
             out.startsWith(s"""```scala title="$path""""),
             out.contains("val x = 1"),
             out.trim.endsWith("```"),
-            !out.contains("showLineNumbers"),
+            !out.contains("showLineNumbers")
           )
         },
         test("comment=false omits title") {
@@ -85,7 +85,7 @@ object SourceFileSpec extends ZIOSpecDefault {
           }
           assertTrue(
             out.startsWith("```scala\n"),
-            !out.contains("title="),
+            !out.contains("title=")
           )
         },
         test("showLineNumbers=true adds showLineNumbers") {
@@ -103,7 +103,7 @@ object SourceFileSpec extends ZIOSpecDefault {
           } finally {
             Files.delete(tmp)
           }
-        },
-      ),
+        }
+      )
     )
 }


### PR DESCRIPTION
## Summary

Promote source file embedding utilities from zio-http into zio-sbt-source as reusable library.

- **SourceFile** — `readSource`, `fileExtension`, `printSource` for embedding source files in mdoc docs
  - Handles relative paths with `../` fallback (mdoc runs in docs subdir)
  - Proper resource cleanup via try/finally
  - Both Scala 2.13 + 3.3.8 supported

- **EmbedSourceModifier** — mdoc PostModifier wrapping SourceFile
  - Usage: ` ```scala mdoc:embed:path/to/file.scala ` ` (no imports needed)
  - Auto-discovered via ServiceLoader (META-INF/services registration)
  - mdoc 2.5.4 added as dependency

## Test Coverage

- 30 tests pass on Scala 2.13 and 3.3.8
- fileExtension edge cases (no ext, mixed cases)
- readSource full file + single-line
- printSource formatting with/without title, with/without line numbers
- Temp file isolation using ZIO Test patterns

## Usage

In any mdoc documentation:

\`\`\`scala mdoc:embed:zio-http-example/src/main/scala/example/HelloWorld.scala
\`\`\`

Projects add \`zio-sbt-source\` as dependency; modifier is auto-discovered.

🤖 Generated with Claude Code