### PR TITLE
Fix: Trigger update-readme only on published release events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,8 @@ jobs:
     name: Update README
     runs-on: ubuntu-latest
     continue-on-error: false
-    if: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+    needs:
+    - release
     steps:
     - name: Git Checkout
       uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,8 +108,7 @@ jobs:
     name: Update README
     runs-on: ubuntu-latest
     continue-on-error: false
-    needs:
-    - release
+    if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
     steps:
     - name: Git Checkout
       uses: actions/checkout@v6

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Agent Instructions
+
+**Never commit to `main`. Checkout feature/bugfix branch first.**
+
+After doc generation, run:
+```bash
+sbt scalafmtAll
+sbt "++2.13; check"
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,3 @@
 
 **Never commit to `main`. Checkout feature/bugfix branch first.**
 
-After doc generation, run:
-```bash
-sbt scalafmtAll
-sbt "++2.13; check"
-```

--- a/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
+++ b/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
@@ -355,9 +355,8 @@ object ZioSbtCiPlugin extends AutoPlugin {
       Job(
         id = "update-readme",
         name = "Update README",
-        condition = updateReadmeCondition orElse Some(
-          Condition.Expression("github.ref == format('refs/heads/{0}', github.event.repository.default_branch)")
-        ),
+        need = Seq("release"),
+        condition = updateReadmeCondition,
         steps = (if (swapSizeGB > 0) Seq(setSwapSpace) else Seq.empty) ++
           Seq(
             checkout,

--- a/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
+++ b/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
@@ -355,8 +355,10 @@ object ZioSbtCiPlugin extends AutoPlugin {
       Job(
         id = "update-readme",
         name = "Update README",
-        need = Seq("release"),
-        condition = updateReadmeCondition,
+        condition = updateReadmeCondition orElse Some(
+          Condition.Expression("github.event_name == 'release'") &&
+            Condition.Expression("github.event.action == 'published'")
+        ),
         steps = (if (swapSizeGB > 0) Seq(setSwapSpace) else Seq.empty) ++
           Seq(
             checkout,


### PR DESCRIPTION
## Summary
- Trigger `update-readme` job only on published release events
- Replace branch-ref condition with release-event condition
- Fixes README not updating after releases (e.g., v0.6.0)

## Changes
- `ZioSbtCiPlugin.scala`: Update `updateReadmeJobs` condition from branch-ref check to `github.event_name == 'release' && github.event.action == 'published'`
- Regenerate `.github/workflows/ci.yml` with new condition
- Add `AGENTS.md` with agent commit workflow instructions

## Test Plan
- [ ] Next release run — verify `update-readme` executes
- [ ] Push to main — verify `update-readme` skipped (not a release event)
- [ ] Verify README has correct version after release

🤖 Generated with [Claude Code](https://claude.com/claude-code)