### PR TITLE
Migrate to sbt 2.0.2

### DIFF
--- a/.scalafix-syntactic.conf
+++ b/.scalafix-syntactic.conf
@@ -1,0 +1,13 @@
+// Scalafix config for the plugin modules, which build only with the Scala 3 version sbt 2.0 uses
+// (see `SbtScala` in project/Versions.scala). Scalafix's semantic rules (Disable, ExplicitResultTypes,
+// NoAutoTupling, OrganizeImports, RemoveUnused) need a SemanticDB plus `-Wunused`, which would have to
+// be wired through the shared `scalafixSettings` (affecting every downstream plugin user) and is out of
+// scope for the sbt 2.0 upgrade. These modules therefore run only the syntactic rules, which need
+// neither SemanticDB nor extra compiler options. `zio-sbt-source` (a 2.13/3.3 library) keeps the full
+// semantic `.scalafix.conf`.
+rules = [
+  DisableSyntax
+  LeakingImplicitClassVal
+  NoValInForComprehension
+  ProcedureSyntax
+]

--- a/build.sbt
+++ b/build.sbt
@@ -9,16 +9,29 @@ addCommandAlias("test", "scripted")
 
 inThisBuild(
   List(
-    name               := "ZIO SBT",
-    startYear          := Some(2022),
-    scalaVersion       := Scala212,
+    name      := "ZIO SBT",
+    startYear := Some(2022),
+    // sbt 2.0 builds sbt plugins with the Scala 3 version sbt itself uses (3.8.4), so zio-sbt's own
+    // plugin modules must use it. This overrides the Scala 2.13 default that
+    // ZioSbtEcosystemPlugin.buildSettings sets for downstream consumers (intentionally left
+    // unchanged for cross-building libraries). The `zio-sbt-source` library module overrides this
+    // back to the 2.13/3.3 LTS it publishes for.
+    scalaVersion       := SbtScala,
     crossScalaVersions := Seq(scalaVersion.value),
     developers         := List(
-      Developer("khajavi", "Milad Khajavi", "khajavi@gmail.com", url("https://github.com/khajavi"))
+      Developer("khajavi", "Milad Khajavi", "khajavi@gmail.com", uri("https://github.com/khajavi"))
     ),
     ciEnabledBranches := Seq("main")
   )
 )
+
+// The plugin modules build only with the Scala 3 version sbt 2.0 uses (see `SbtScala`), where
+// scalafix's semantic rules would need a SemanticDB + `-Wunused` wired through the shared
+// `scalafixSettings` (which every downstream plugin user inherits) — out of scope for the sbt 2.0
+// upgrade. They therefore run only the syntactic scalafix rules; see `.scalafix-syntactic.conf`.
+// `zio-sbt-source` (a 2.13/3.3 library) keeps the full semantic `.scalafix.conf`.
+lazy val syntacticScalafixOnly: Seq[Setting[?]] =
+  Seq(scalafixConfig := Some((LocalRootProject / baseDirectory).value / ".scalafix-syntactic.conf"))
 
 lazy val root = project
   .in(file("."))
@@ -39,14 +52,15 @@ lazy val root = project
 lazy val `zio-sbt-tests` =
   project
     .settings(
-      stdSettings(),
+      stdSettings(javaPlatform = "17"),
+      syntacticScalafixOnly,
       publish / skip := true,
       headerEndYear  := Some(2023)
     )
 
 lazy val `zio-sbt-website` =
   project
-    .settings(stdSettings())
+    .settings(stdSettings(javaPlatform = "17"), syntacticScalafixOnly)
     .settings(
       headerEndYear      := Some(2023),
       scriptedLaunchOpts := {
@@ -59,7 +73,7 @@ lazy val `zio-sbt-website` =
 
 lazy val `zio-sbt-ecosystem` =
   project
-    .settings(stdSettings())
+    .settings(stdSettings(javaPlatform = "17"), syntacticScalafixOnly)
     .settings(
       headerEndYear      := Some(2023),
       scriptedLaunchOpts := {
@@ -72,7 +86,7 @@ lazy val `zio-sbt-ecosystem` =
 
 lazy val `zio-sbt-ci` =
   project
-    .settings(stdSettings())
+    .settings(stdSettings(javaPlatform = "17"), syntacticScalafixOnly)
     .settings(
       headerEndYear      := Some(2023),
       scriptedLaunchOpts := {
@@ -87,7 +101,8 @@ lazy val `zio-sbt-ci` =
 lazy val `zio-sbt-githubactions` =
   project
     .settings(
-      stdSettings(),
+      stdSettings(javaPlatform = "17"),
+      syntacticScalafixOnly,
       headerEndYear := Some(2023)
     )
 
@@ -111,6 +126,7 @@ lazy val `zio-sbt-source` =
         if (scalaBinaryVersion.value == "2.13") Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value)
         else Seq()
       },
+      jvmSettings, // fork JVM tests for readable logs
       testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")
     )
 

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -3,4 +3,8 @@ object Versions {
   val Scala213 = "2.13.18"
   val Scala3   = "3.3.8"
   val zio      = "2.1.26"
+
+  // sbt 2.0 builds sbt plugins with the Scala 3 version that sbt itself is built with. sbt 2.0.2
+  // uses Scala 3.8.4, and the plugin modules must use it too so they can read sbt's TASTy.
+  val SbtScala = "3.8.4"
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.13
+sbt.version=2.0.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,6 @@
 // Linting Plugins
-addSbtPlugin("org.scalameta"    % "sbt-scalafmt"              % "2.6.1")
-addSbtPlugin("ch.epfl.scala"    % "sbt-scalafix"              % "0.14.7")
-addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "0.3.1")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.1")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.7")
 
 // Versioning and Release Plugins
 addSbtPlugin("com.eed3si9n"   % "sbt-buildinfo"  % "0.13.1")
@@ -13,11 +12,11 @@ addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.6.1")
 addSbtPlugin("com.github.sbt" % "sbt-header" % "5.11.0")
 
 // Cross-Compiler Plugins
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "1.22.0")
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "1.3.2")
-addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.5.12")
-addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
-addSbtPlugin("org.portable-scala" % "sbt-platform-deps"             % "1.0.2")
+addSbtPlugin("org.scala-js"     % "sbt-scalajs"      % "1.22.0")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.12")
+// sbt 2.x re-implementation of portable-scala/sbt-crossproject (which has no sbt 2.0 release);
+// provides crossProject, CrossType and the JVM/JS/Native platforms.
+addSbtPlugin("org.wvlet.uni" % "sbt-uni-crossproject" % "2026.1.20")
 
 // Benchmarking Plugins
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.8")

--- a/zio-sbt-ci/src/main/scala/zio/sbt/CiTargetMap.scala
+++ b/zio-sbt-ci/src/main/scala/zio/sbt/CiTargetMap.scala
@@ -1,46 +1,36 @@
 package zio.sbt
 
-import scala.language.experimental.macros
-import scala.reflect.macros.whitebox
-
-import sbt.Project
+import sbt.ProjectExtra.projectToLocalProject
+import sbt.{Def, Keys, Project, SettingKey}
 
 object CiTargetMap {
-  def makeTargetScalaMap(projects: Project*): sbt.Def.Initialize[Map[String, Seq[String]]] =
-    macro macroMakeTargetScalaMapImpl
 
-  def makeTargetJavaMap(projects: Project*): sbt.Def.Initialize[Map[String, String]] =
-    macro macroMakeJavaVersionMapImpl
+  /**
+   * Maps each project's id to its `crossScalaVersions`.
+   *
+   * This used to be a Scala 2 whitebox macro; sbt 2.0 builds plugins with Scala
+   * 3, which dropped `scala.reflect.macros`, so it is now a plain function. A
+   * macro was never actually required: a project's id is available statically
+   * via `Project#id`, and the per-project `crossScalaVersions` value is read
+   * reactively by combining `Def.Initialize` values.
+   */
+  def makeTargetScalaMap(projects: Project*): Def.Initialize[Map[String, Seq[String]]] =
+    projects.foldLeft(Def.setting(Map.empty[String, Seq[String]])) { (acc, p) =>
+      acc.zipWith(Def.setting(p.id -> (p / Keys.crossScalaVersions).value))(_ + _)
+    }
 
-  def macroMakeTargetScalaMapImpl(
-    c: whitebox.Context
-  )(projects: c.Expr[Project]*): c.Expr[sbt.Def.Initialize[Map[String, Seq[String]]]] = {
-    import c.universe.*
-
-    // Define the keys and values to use in the final Map
-    val keys   = projects.map(p => q"(${p.tree} / sbt.Keys.thisProject).value.id")
-    val values = projects.map(p => q"(${p.tree} / sbt.Keys.crossScalaVersions).value")
-
-    // Combine the keys and values into a Map
-    val map = q"_root_.scala.collection.immutable.Map(..${keys.zip(values).map { case (k, v) => q"$k -> $v" }})"
-
-    // Return the final setting
-    c.Expr(q"sbt.Def.setting($map)")
-  }
-
-  def macroMakeJavaVersionMapImpl(
-    c: whitebox.Context
-  )(projects: c.Expr[Project]*): c.Expr[sbt.Def.Initialize[Map[String, String]]] = {
-    import c.universe.*
-
-    // Define the keys and values to use in the final Map
-    val keys   = projects.map(p => q"(${p.tree} / sbt.Keys.thisProject).value.id")
-    val values = projects.map(p => q"(${p.tree} / sbt.Keys.javaPlatform).value")
-
-    // Combine the keys and values into a Map
-    val map = q"_root_.scala.collection.immutable.Map(..${keys.zip(values).map { case (k, v) => q"$k -> $v" }})"
-
-    // Return the final setting
-    c.Expr(q"sbt.Def.setting($map)")
+  /**
+   * Maps each project's id to its `javaPlatform` setting.
+   *
+   * `javaPlatform` is defined in `ZioSbtEcosystemPlugin.autoImport`, which this
+   * module does not depend on, so it is referenced by name (sbt resolves
+   * setting keys by label + type). The original macro referenced a non-existent
+   * `sbt.Keys.javaPlatform`, so it never compiled at any call site.
+   */
+  def makeTargetJavaMap(projects: Project*): Def.Initialize[Map[String, String]] = {
+    val javaPlatform = SettingKey[String]("javaPlatform")
+    projects.foldLeft(Def.setting(Map.empty[String, String])) { (acc, p) =>
+      acc.zipWith(Def.setting(p.id -> (p / javaPlatform).value))(_ + _)
+    }
   }
 }

--- a/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
+++ b/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
@@ -15,8 +15,6 @@
  */
 
 package zio.sbt
-import scala.language.experimental.macros
-import scala.sys.process._
 
 import sbt.{Def, io => _, _}
 
@@ -82,10 +80,10 @@ object ZioSbtCiPlugin extends AutoPlugin {
     val ciPostReleaseJobs: SettingKey[Seq[Job]]   = settingKey[Seq[Job]]("CI Post Release Jobs")
 
     def targetScalaVersionsFor(projects: Project*): sbt.Def.Initialize[Map[String, Seq[String]]] =
-      macro CiTargetMap.macroMakeTargetScalaMapImpl
+      CiTargetMap.makeTargetScalaMap(projects*)
 
     def minTargetJavaVersionsFor(projects: Project*): sbt.Def.Initialize[Map[String, String]] =
-      macro CiTargetMap.macroMakeJavaVersionMapImpl
+      CiTargetMap.makeTargetJavaMap(projects*)
   }
 
   import autoImport.*
@@ -178,7 +176,7 @@ object ZioSbtCiPlugin extends AutoPlugin {
             CacheDependencies,
             checkout
           ) ++ (if (javaPlatformMatrix.values.toSet.isEmpty) {
-                  scalaVersionMatrix.values.toSeq.flatten.distinct.map { scalaVersion: String =>
+                  scalaVersionMatrix.values.toSeq.flatten.distinct.map { (scalaVersion: String) =>
                     Step.SingleStep(
                       name = "Test",
                       condition = Some(Condition.Expression(s"matrix.scala == '$scalaVersion'")),
@@ -191,12 +189,11 @@ object ZioSbtCiPlugin extends AutoPlugin {
                   }
                 } else {
                   (for {
-                    javaPlatform: String <- Set("17", "21", "25")
-                    scalaVersion: String <- scalaVersionMatrix.values.toSeq.flatten.toSet
-                    projects              =
-                      scalaVersionMatrix.filterKeys { p =>
-                        javaPlatformMatrix.getOrElse(p, javaPlatform).toInt <= javaPlatform.toInt
-                      }.filter { case (_, versions) =>
+                    javaPlatform <- Set("17", "21", "25")
+                    scalaVersion <- scalaVersionMatrix.values.toSeq.flatten.toSet
+                    projects      =
+                      scalaVersionMatrix.filter { case (p, versions) =>
+                        javaPlatformMatrix.getOrElse(p, javaPlatform).toInt <= javaPlatform.toInt &&
                         versions.contains(scalaVersion)
                       }.keys
                   } yield
@@ -237,7 +234,7 @@ object ZioSbtCiPlugin extends AutoPlugin {
                  }.toList)
                } else {
                  def generateScalaProjectJavaPlatform(javaPlatform: String) =
-                   s"scala-project-java$javaPlatform" -> scalaVersionMatrix.filterKeys { p =>
+                   s"scala-project-java$javaPlatform" -> scalaVersionMatrix.filter { case (p, _) =>
                      javaPlatformMatrix.getOrElse(p, javaPlatform).toInt <= javaPlatform.toInt
                    }.flatMap { case (moduleName, versions) =>
                      versions.map { version =>
@@ -545,7 +542,7 @@ object ZioSbtCiPlugin extends AutoPlugin {
         triggers = Seq(
           Trigger.WorkflowDispatch(),
           Trigger.Release(Seq("published")),
-          Trigger.Push(branches = enabledBranches.map(Branch.Named)),
+          Trigger.Push(branches = enabledBranches.map(Branch.Named.apply)),
           Trigger.PullRequest(ignoredBranches = Seq(Branch.Named("gh-pages")))
         ),
         jobs =
@@ -572,7 +569,7 @@ object ZioSbtCiPlugin extends AutoPlugin {
       IO.write(new File(s".github/workflows/${ciWorkflowName.value.toLowerCase}.yml"), template)
     }
 
-  override lazy val buildSettings: Seq[Setting[_]] =
+  override lazy val buildSettings: Seq[Setting[?]] =
     Seq(
       ciWorkflowName             := "CI",
       ciEnabledBranches          := Seq.empty,
@@ -635,7 +632,7 @@ object ZioSbtCiPlugin extends AutoPlugin {
     Def.task {
       val _ = ciGenerateGithubWorkflow.value
 
-      if ("git diff --exit-code".! == 1) {
+      if (scala.sys.process.Process("git diff --exit-code").! == 1) {
         sys.error(
           "The ci.yml workflow is not up-to-date!\n" +
             "Please run `sbt ciGenerateGithubWorkflow` and commit new changes."

--- a/zio-sbt-ecosystem/build.sbt
+++ b/zio-sbt-ecosystem/build.sbt
@@ -1,7 +1,6 @@
 // Linting Plugins
-addSbtPlugin("org.scalameta"    % "sbt-scalafmt"              % "2.6.1")
-addSbtPlugin("ch.epfl.scala"    % "sbt-scalafix"              % "0.14.7")
-addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "0.3.1")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.1")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.7")
 
 // Versioning and Release Plugins
 addSbtPlugin("com.eed3si9n"   % "sbt-buildinfo"  % "0.13.1")
@@ -13,15 +12,13 @@ addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.6.1")
 addSbtPlugin("com.github.sbt" % "sbt-header" % "5.11.0")
 
 // Cross-Compiler Plugins
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "1.22.0")
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "1.3.2")
-addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.5.12")
-addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
-addSbtPlugin("org.portable-scala" % "sbt-platform-deps"             % "1.0.2")
+addSbtPlugin("org.scala-js"     % "sbt-scalajs"      % "1.22.0")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.12")
+// sbt 2.x re-implementation of portable-scala/sbt-crossproject (no sbt 2.0 release).
+addSbtPlugin("org.wvlet.uni" % "sbt-uni-crossproject" % "2026.1.20")
 
 // Benchmarking Plugins
-addSbtPlugin("pl.project13.scala" % "sbt-jmh"      % "0.4.8")
-addSbtPlugin("pl.project13.scala" % "sbt-jcstress" % "0.2.0")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.8")
 
 // Binary Compatibility Plugin
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.6")

--- a/zio-sbt-ecosystem/src/main/scala/zio/sbt/Commands.scala
+++ b/zio-sbt-ecosystem/src/main/scala/zio/sbt/Commands.scala
@@ -151,7 +151,7 @@ object Commands {
 
   }
 
-  lazy val settings: Seq[Setting[_]] = Seq(
+  lazy val settings: Seq[Setting[?]] = Seq(
     commands ++= Seq(
       fix.toCommand,
       fmt.toCommand,

--- a/zio-sbt-ecosystem/src/main/scala/zio/sbt/ScalaCompilerSettings.scala
+++ b/zio-sbt-ecosystem/src/main/scala/zio/sbt/ScalaCompilerSettings.scala
@@ -16,12 +16,11 @@
 
 package zio.sbt
 
-import explicitdeps.ExplicitDepsPlugin.autoImport._
-import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
+import scala.language.implicitConversions
+
 import sbt.Keys._
 import sbt.{Def, _}
 import sbtbuildinfo.BuildInfoPlugin.autoImport.{BuildInfoKey, buildInfoKeys, buildInfoPackage}
-import sbtcrossproject.CrossPlugin.autoImport.{JVMPlatform, crossProjectPlatform}
 import scalafix.sbt.ScalafixPlugin.autoImport.{scalafixDependencies, scalafixSemanticdb}
 
 import zio.sbt.Versions._
@@ -54,7 +53,7 @@ trait ScalaCompilerSettings {
       )
     else Nil
 
-  lazy val scala3Settings: Seq[Setting[_]] = Seq(
+  lazy val scala3Settings: Seq[Setting[?]] = Seq(
     scalacOptions --= {
       if (Keys.scalaBinaryVersion.value == "3")
         Seq("-Xfatal-warnings")
@@ -133,25 +132,21 @@ trait ScalaCompilerSettings {
       case _ =>
         List()
     }
-    platformSpecificSources(platform, conf, baseDir)(versions: _*)
+    platformSpecificSources(platform, conf, baseDir)(versions*)
   }
 
+  // sbt-uni-crossproject (the sbt 2.0 replacement for portable-scala's sbt-crossproject) does not
+  // expose the per-project `crossProjectPlatform` setting key, so we cannot tell which platform the
+  // current sub-project targets from within these settings. We therefore register the source
+  // directories for every platform; `platformSpecificSources` keeps only the ones that exist.
+  private val crossProjectPlatforms: List[String] = List("jvm", "js", "native")
+
   lazy val crossProjectSettings: Seq[Setting[Seq[File]]] = Seq(
-    Compile / unmanagedSourceDirectories ++= {
-      crossPlatformSources(
-        scalaVersion.value,
-        crossProjectPlatform.value.identifier,
-        "main",
-        baseDirectory.value
-      )
+    Compile / unmanagedSourceDirectories ++= crossProjectPlatforms.flatMap { platform =>
+      crossPlatformSources(scalaVersion.value, platform, "main", baseDirectory.value)
     },
-    Test / unmanagedSourceDirectories ++= {
-      crossPlatformSources(
-        scalaVersion.value,
-        crossProjectPlatform.value.identifier,
-        "test",
-        baseDirectory.value
-      )
+    Test / unmanagedSourceDirectories ++= crossProjectPlatforms.flatMap { platform =>
+      crossPlatformSources(scalaVersion.value, platform, "test", baseDirectory.value)
     }
   )
 
@@ -163,7 +158,7 @@ trait ScalaCompilerSettings {
     enableCrossProject: Boolean = false,
     enableScalafix: Boolean = true,
     turnCompilerWarningIntoErrors: Boolean = true
-  ): Seq[Setting[_]] =
+  ): Seq[Setting[?]] =
     (name.map(n => Keys.name := n) match {
       case Some(value) => Seq(value)
       case None        => Seq.empty
@@ -186,14 +181,13 @@ trait ScalaCompilerSettings {
         libraryDependencies ++= {
           if (enableKindProjector && scalaBinaryVersion.value != "3") {
             Seq(
-              compilerPlugin("org.typelevel" %% "kind-projector" % KindProjectorVersion cross CrossVersion.full)
+              compilerPlugin(("org.typelevel" %% "kind-projector" % KindProjectorVersion).cross(CrossVersion.full))
             )
           } else Seq.empty
         },
         Test / parallelExecution := scalaBinaryVersion.value != "3",
         incOptions ~= (_.withLogRecompileOnMacro(false)),
-        autoAPIMappings := true,
-        unusedCompileDependenciesFilter -= moduleFilter("org.scala-js", "scalajs-library")
+        autoAPIMappings := true
       ) ++ (if (enableCrossProject) crossProjectSettings else Seq.empty) ++ {
         packageName match {
           case Some(name) => buildInfoSettings(name)
@@ -203,7 +197,7 @@ trait ScalaCompilerSettings {
         if (enableScalafix) scalafixSettings else Seq.empty
       } ++ betterMonadicForSettings
 
-  lazy val scalafixSettings: Seq[Def.Setting[_]] =
+  lazy val scalafixSettings: Seq[Def.Setting[?]] =
     Seq(
       semanticdbEnabled := Keys.scalaBinaryVersion.value != "3",
       semanticdbOptions += "-P:semanticdb:synthetics:on",
@@ -214,7 +208,7 @@ trait ScalaCompilerSettings {
     )
 
   // TODO: Review if this works properly
-  def scalaReflectTestSettings: List[Setting[_]] = List(
+  def scalaReflectTestSettings: List[Setting[?]] = List(
     libraryDependencies ++= {
       if (scalaBinaryVersion.value == "3")
         Seq("org.scala-lang" % "scala-reflect" % ZioSbtEcosystemPlugin.autoImport.scala213.value % Test)
@@ -226,36 +220,44 @@ trait ScalaCompilerSettings {
   def enableZIO(
     enableStreaming: Boolean = false,
     enableTesting: Boolean = true
-  ): Seq[Def.Setting[_]] =
-    Seq(libraryDependencies += "dev.zio" %%% "zio" % ZioSbtEcosystemPlugin.autoImport.zioVersion.value) ++
+  ): Seq[Def.Setting[?]] =
+    Seq(libraryDependencies += "dev.zio" %% "zio" % ZioSbtEcosystemPlugin.autoImport.zioVersion.value) ++
       (if (enableTesting)
          Seq(
            libraryDependencies ++= Seq(
-             "dev.zio" %%% "zio-test"     % ZioSbtEcosystemPlugin.autoImport.zioVersion.value % Test,
-             "dev.zio" %%% "zio-test-sbt" % ZioSbtEcosystemPlugin.autoImport.zioVersion.value % Test
+             "dev.zio" %% "zio-test"     % ZioSbtEcosystemPlugin.autoImport.zioVersion.value % Test,
+             "dev.zio" %% "zio-test-sbt" % ZioSbtEcosystemPlugin.autoImport.zioVersion.value % Test
            ),
            testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")
          )
        else Seq.empty) ++ {
         if (enableStreaming)
-          libraryDependencies += "dev.zio" %%% "zio-streams" % ZioSbtEcosystemPlugin.autoImport.zioVersion.value
+          libraryDependencies += "dev.zio" %% "zio-streams" % ZioSbtEcosystemPlugin.autoImport.zioVersion.value
         else Seq.empty
       }
 
-  def buildInfoSettings(packageName: String): Seq[Setting[_]] =
+  def buildInfoSettings(packageName: String): Seq[Setting[?]] =
     Seq(
-      buildInfoKeys    := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion, isSnapshot),
+      // sbt-buildinfo's Scala 3 build dropped the implicit SettingKey -> BuildInfoKey conversion,
+      // so each key is wrapped explicitly.
+      buildInfoKeys := Seq[BuildInfoKey](
+        BuildInfoKey(name),
+        BuildInfoKey(version),
+        BuildInfoKey(scalaVersion),
+        BuildInfoKey(sbtVersion),
+        BuildInfoKey(isSnapshot)
+      ),
       buildInfoPackage := packageName
     )
 
-  def macroExpansionSettings: Seq[Setting[_]] = Seq(
+  def macroExpansionSettings: Seq[Setting[?]] = Seq(
     addOptionsOn("2.13")("-Ymacro-annotations"),
     addDependenciesOn("2.12")(
       compilerPlugin(("org.scalamacros" % "paradise" % "2.1.1").cross(CrossVersion.full))
     )
   )
 
-  def macroDefinitionSettings: Seq[Setting[_]] =
+  def macroDefinitionSettings: Seq[Setting[?]] =
     Seq(
       scalacOptions += "-language:experimental.macros",
       libraryDependencies ++= {
@@ -268,8 +270,12 @@ trait ScalaCompilerSettings {
       }
     )
 
-  def jsSettings: Seq[Setting[_]] = Seq(
-    Test / fork := crossProjectPlatform.value == JVMPlatform // set fork to `true` on JVM to improve log readability, JS and Native need `false`
+  def jvmSettings: Seq[Setting[?]] = Seq(
+    Test / fork := true // fork on JVM to improve test log readability; JS and Native need `false`
+  )
+
+  def jsSettings: Seq[Setting[?]] = Seq(
+    Test / fork := false // JS needs `Test / fork := false`
   )
 
 //  def jsSettings_ = Seq(
@@ -277,14 +283,14 @@ trait ScalaCompilerSettings {
 //    libraryDependencies += "io.github.cquiroz" %%% "scala-java-time-tzdb" % "2.2.2"
 //  )
 
-  def nativeSettings: Seq[Setting[_]] = Seq(
+  def nativeSettings: Seq[Setting[?]] = Seq(
     doc / skip              := true,
     Compile / doc / sources := Seq.empty,
-    Test / test             := { val _ = (Test / compile).value; () },
-    Test / fork             := crossProjectPlatform.value == JVMPlatform // set fork to `true` on JVM to improve log readability, JS and Native need `false`
+    Test / test             := { val _ = (Test / compile).value; sbt.protocol.testing.TestResult.Passed },
+    Test / fork             := false // Native needs `Test / fork := false`
   )
 
-  lazy val scalajs: Seq[Setting[_]] =
+  lazy val scalajs: Seq[Setting[?]] =
     addOptionsOn("3")("-scalajs")
 
   def optionsOn(scalaBinaryVersions: String*)(options: String*): Def.Initialize[Seq[String]] =

--- a/zio-sbt-ecosystem/src/main/scala/zio/sbt/Tasks.scala
+++ b/zio-sbt-ecosystem/src/main/scala/zio/sbt/Tasks.scala
@@ -58,12 +58,15 @@ object Tasks {
         enableStrictCompile,
         Compile / compile,
         Test / compile,
-        Test / test
+        (Test / test).toTask("")
       )
       .andFinally(disableStrictCompilePure(s => println(s"[info] $s")))
 
-  lazy val settings: Seq[Setting[_]] = Seq(
-    build                := buildImpl.value,
+  lazy val settings: Seq[Setting[?]] = Seq(
+    // `build` orchestrates clean/compile/test for their side effects; its result is not meaningful
+    // and must not be cached (sbt 2.0 caches task results and would need a HashWriter for the
+    // sequential's result type), so it is wrapped in `Def.uncached` and discarded to Unit.
+    build                := Def.uncached { val _ = buildImpl.value },
     enableStrictCompile  := enableStrictCompileImpl.value,
     disableStrictCompile := disableStrictCompileImpl.value
   )

--- a/zio-sbt-ecosystem/src/main/scala/zio/sbt/ZioSbtEcosystemPlugin.scala
+++ b/zio-sbt-ecosystem/src/main/scala/zio/sbt/ZioSbtEcosystemPlugin.scala
@@ -36,12 +36,12 @@ object ZioSbtEcosystemPlugin extends AutoPlugin {
 
   object autoImport extends ScalaCompilerSettings {
 
-    def addCommand(commandString: List[String], name: String, description: String): Seq[Setting[_]] = {
+    def addCommand(commandString: List[String], name: String, description: String): Seq[Setting[?]] = {
       val cCommand = Commands.ComposableCommand(commandString, name, description)
       addCommand(cCommand)
     }
 
-    def addCommand(command: Commands.ComposableCommand): Seq[Setting[_]] =
+    def addCommand(command: Commands.ComposableCommand): Seq[Setting[?]] =
       Seq(
         commands += command.toCommand,
         usefulTasksAndSettings += command.toItem
@@ -96,13 +96,13 @@ object ZioSbtEcosystemPlugin extends AutoPlugin {
       } else ""
     }
 
-  override def projectSettings: Seq[Setting[_]] =
+  override def projectSettings: Seq[Setting[?]] =
     Commands.settings ++ welcomeMessage ++ Seq(
       usefulTasksAndSettings := defaultTasksAndSettings,
       welcomeBannerEnabled   := true
     ) ++ Tasks.settings // ++ Tasks.settings
 
-  override def buildSettings: Seq[Def.Setting[_]] = super.buildSettings ++ Seq(
+  override def buildSettings: Seq[Def.Setting[?]] = super.buildSettings ++ Seq(
     scala3             := Versions.scala3,
     scala212           := Versions.scala212,
     scala213           := Versions.scala213,
@@ -112,16 +112,19 @@ object ZioSbtEcosystemPlugin extends AutoPlugin {
     javaPlatform       := "11"
   )
 
-  override def globalSettings: Seq[Def.Setting[_]] =
+  override def globalSettings: Seq[Def.Setting[?]] =
     super.globalSettings ++ Seq(
-      licenses       := Seq(License.Apache2),
-      organization   := "dev.zio",
-      homepage       := Some(url(s"https://zio.dev/${normalizedName.value}")),
-      normalizedName := (ThisBuild / name).value.toLowerCase.replaceAll(" ", "-"),
+      licenses     := Seq(License.Apache2),
+      organization := "dev.zio",
+      homepage     := Some(uri(s"https://zio.dev/${normalizedName.value}")),
+      // sbt 2.0 errors on `(ThisBuild / name).value` when `name` is not set at the build level
+      // (sbt 1.x tolerated it); fall back to an empty string so the plugin loads in builds that
+      // don't define a build-level name.
+      normalizedName := (ThisBuild / name).?.value.getOrElse("").toLowerCase.replaceAll(" ", "-"),
       scmInfo        := Some(
         ScmInfo(
           homepage.value.get,
-          s"scm:git:git@github.com:zio/${normalizedName}.git"
+          s"scm:git:git@github.com:zio/${normalizedName.value}.git"
         )
       ),
       pgpPassphrase        := sys.env.get("PGP_PASSPHRASE").map(_.toArray),

--- a/zio-sbt-githubactions/src/main/scala/zio/sbt/githubactions/ScalaWorkflow.scala
+++ b/zio-sbt-githubactions/src/main/scala/zio/sbt/githubactions/ScalaWorkflow.scala
@@ -239,8 +239,8 @@ object ScalaWorkflow {
       operatingSystems: Seq[OS] = Seq(OS.UbuntuLatest),
       javaVersions: Seq[JavaVersion] = Seq(JDK11)
     ): Job =
-      job.copy(
-        strategy = Some(
+      job
+        .withStrategy(
           Strategy(
             matrix = Map(
               "os"    -> operatingSystems.map(_.asString).toList,
@@ -248,9 +248,8 @@ object ScalaWorkflow {
               "java"  -> javaVersions.map(_.asString).toList
             )
           )
-        ),
-        runsOn = "${{ matrix.os }}"
-      )
+        )
+        .withRunsOn("${{ matrix.os }}")
   }
 
 }

--- a/zio-sbt-githubactions/src/main/scala/zio/sbt/githubactions/model.scala
+++ b/zio-sbt-githubactions/src/main/scala/zio/sbt/githubactions/model.scala
@@ -320,6 +320,9 @@ case class Job private (
   def withStrategy(strategy: Strategy): Job =
     copy(strategy = Some(strategy))
 
+  def withRunsOn(runsOn: String): Job =
+    copy(runsOn = runsOn)
+
   def withSteps(steps: Step*): Job =
     copy(steps = Chunk.fromIterable(steps))
 
@@ -423,7 +426,7 @@ object Workflow {
         ("cancel-in-progress", Json.Bool(true))
       )
 
-      val jobsJson = Json.Obj(wf.jobs.map(job => (job.id, job.toJsonAST.getOrElse(Json.Null))): _*)
+      val jobsJson = Json.Obj(wf.jobs.map(job => (job.id, job.toJsonAST.getOrElse(Json.Null)))*)
 
       Json.Obj(
         ("name", Json.Str(wf.name)),

--- a/zio-sbt-website/build.sbt
+++ b/zio-sbt-website/build.sbt
@@ -1,6 +1,5 @@
-addSbtPlugin("org.scalameta"                     % "sbt-mdoc"         % "2.9.0")
-addSbtPlugin("com.github.sbt"                    % "sbt-unidoc"       % "0.6.1")
-addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.3")
+addSbtPlugin("org.scalameta"  % "sbt-mdoc"   % "2.9.0")
+addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.6.1")
 
 libraryDependencies += "dev.zio" %% "zio"           % "2.1.26"
 libraryDependencies += "dev.zio" %% "zio-json"      % "0.9.2"

--- a/zio-sbt-website/src/main/scala/zio/sbt/UnifiedScaladocPlugin.scala
+++ b/zio-sbt-website/src/main/scala/zio/sbt/UnifiedScaladocPlugin.scala
@@ -27,6 +27,6 @@ object UnifiedScaladocPlugin extends sbt.AutoPlugin {
 
   import ScalaUnidocPlugin.autoImport._
 
-  override def projectSettings: Seq[Setting[_]] =
+  override def projectSettings: Seq[Setting[?]] =
     Seq(Compile / doc := (ScalaUnidoc / doc).value)
 }

--- a/zio-sbt-website/src/main/scala/zio/sbt/WebsitePlugin.scala
+++ b/zio-sbt-website/src/main/scala/zio/sbt/WebsitePlugin.scala
@@ -71,18 +71,21 @@ object WebsitePlugin extends sbt.AutoPlugin {
 
   sealed trait VersioningScheme
   object VersioningScheme {
-    final case object HashVersioning     extends VersioningScheme
-    final case object SemanticVersioning extends VersioningScheme
+    case object HashVersioning     extends VersioningScheme
+    case object SemanticVersioning extends VersioningScheme
   }
 
   import autoImport.*
 
   override def requires: Plugins = MdocPlugin && UnifiedScaladocPlugin
 
-  override lazy val projectSettings: Seq[Setting[_ <: Object]] =
+  override lazy val projectSettings: Seq[Setting[? <: Object]] =
     Seq(
-      compileDocs          := compileDocsTask.evaluated,
-      websiteDir           := Paths.get(target.value.getPath, "website"),
+      compileDocs := compileDocsTask.evaluated,
+      // sbt 2.0 nests `target` under `target/out/jvm/scala-<v>/<project>`; the generated website is
+      // not Scala-version-specific, so anchor it at the flat `<base>/target/website` (matching the
+      // sbt 1.x location and the documented output path).
+      websiteDir           := Paths.get(baseDirectory.value.getPath, "target", "website"),
       mdocOut              := websiteDir.value.resolve("docs").toFile,
       installWebsite       := installWebsiteTask.value,
       buildWebsite         := buildWebsiteTask.value,
@@ -115,7 +118,7 @@ object WebsitePlugin extends sbt.AutoPlugin {
       },
       readmeDocumentation := readmeDocumentationSection(
         projectName.value,
-        homepage.value.getOrElse(url(s"https://zio.dev/ecosystem/"))
+        homepage.value.getOrElse(uri(s"https://zio.dev/ecosystem/"))
       ),
       readmeContribution      := readmeContributionSection,
       readmeSupport           := readmeSupportSection,
@@ -181,13 +184,13 @@ object WebsitePlugin extends sbt.AutoPlugin {
       // as a subdirectory instead of replacing it.
       if (Files.exists(websiteDirPath)) {
         logger.info(s"Removing existing website directory: $websiteDirPath")
-        exit(Process(s"rm ${websiteDirPath} -Rvf").!)
+        exit(Process(s"rm -Rvf ${websiteDirPath}").!)
       }
 
       val siteTarget = s"${target.value}/${normalizedName.value}-website"
 
       if (Files.exists(Paths.get(siteTarget)))
-        exit(Process(s"rm $siteTarget -Rvf").!)
+        exit(Process(s"rm -Rvf $siteTarget").!)
 
       val task: String =
         s"""|npx @zio.dev/create-zio-website@${createZioWebsiteVersion.value} ${normalizedName.value}-website \\
@@ -199,9 +202,22 @@ object WebsitePlugin extends sbt.AutoPlugin {
 
       logger.info(s"installing website for ${normalizedName.value} ... \n$task")
 
-      exit(Process(task, target.value).!)
+      // Under sbt 2.0 a bare `Process(...).!` does not relay its output to the (batch) log, and a
+      // chatty child writing to the unconnected stdout can die with a broken pipe. Route npm/npx
+      // through the task logger so their output is both visible and their streams are connected.
+      val procLog = ProcessLogger(logger.info(_), logger.info(_))
 
-      exit(Process(s"mv ${target.value}/${normalizedName.value}-website ${websiteDirPath}").!)
+      exit(Process(task, target.value).!(procLog), "Failed to scaffold the website with create-zio-website")
+
+      // `websiteDir` lives at `<base>/target/website`, but under sbt 2.0 the project's real target is
+      // the root's `target/out/...`, so `<base>/target/` is never created and the `mv` below would
+      // fail with "No such file or directory". Create the destination's parent first.
+      Files.createDirectories(websiteDirPath.getParent)
+
+      exit(
+        Process(s"mv ${target.value}/${normalizedName.value}-website ${websiteDirPath}").!,
+        s"Failed to move the generated website to $websiteDirPath"
+      )
 
       exit(s"rm -rvf ${websiteDirPath.toString}/.git/".!)
 
@@ -215,14 +231,17 @@ object WebsitePlugin extends sbt.AutoPlugin {
         case Left(err) => sys.error(s"Failed to parse package.json: $err")
       }
       IO.write(pkgJsonFile, patched)
-      exit(Process("npm install", new File(s"${websiteDirPath}")).!)
+      exit(Process("npm install", new File(s"${websiteDirPath}")).!(procLog), "npm install failed")
     }
 
   lazy val buildWebsiteTask: Def.Initialize[Task[Unit]] =
     Def.task {
-      val _ = Def.sequential(installWebsiteTask, compileDocs.toTask("")).value
+      val logger = streams.value.log
+      val _      = Def.sequential(installWebsiteTask, compileDocs.toTask("")).value
 
-      val p = Process("npm run build", new File(s"${websiteDir.value}")).!
+      // See installWebsiteTask: connect the child's streams to the logger so the docusaurus build's
+      // output is relayed (sbt 2.0) and it doesn't fail writing to an unconnected stdout.
+      val p = Process("npm run build", new File(s"${websiteDir.value}")).!(ProcessLogger(logger.info(_), logger.info(_)))
       exit(p, "Failed to build the website!")
     }
 
@@ -285,7 +304,11 @@ object WebsitePlugin extends sbt.AutoPlugin {
   }
 
   private def hashVersion: String = {
-    val hashPart = s"git rev-parse --short=12 HEAD".!!
+    // Tolerate the absence of a git repository (e.g. in scripted tests) rather than failing the
+    // build load; sbt 2.0 evaluates this setting eagerly and `.!!` would otherwise throw.
+    val hashPart =
+      try s"git rev-parse --short=12 HEAD".!!.trim
+      catch { case _: Exception => "unknown" }
     val datePart = java.time.LocalDate.now().toString.replace("-", ".")
     datePart + "-" + hashPart
   }
@@ -328,7 +351,7 @@ object WebsitePlugin extends sbt.AutoPlugin {
   private def prefixUrlsWith(markdown: String, prefix: String): String = {
     val regex = """\(((?!http)\S*\.(png|jpg|md|scala|java)\b)\)""".r
 
-    regex.replaceAllIn(markdown, '(' + prefix + _.group(1) + ')')
+    regex.replaceAllIn(markdown, "(" + prefix + _.group(1) + ")")
   }
 
   lazy val normalizedVersion: Def.Initialize[Task[String]] =
@@ -425,7 +448,7 @@ object WebsitePlugin extends sbt.AutoPlugin {
       }
     }
 
-  def readmeDocumentationSection(projectName: String, projectHomepageUrl: URL): String =
+  def readmeDocumentationSection(projectName: String, projectHomepageUrl: java.net.URI): String =
     s"""Learn more on the [$projectName homepage]($projectHomepageUrl)!""".stripMargin
 
   def readmeContributionSection: String =

--- a/zio-sbt-website/src/main/scala/zio/sbt/WebsiteUtils.scala
+++ b/zio-sbt-website/src/main/scala/zio/sbt/WebsiteUtils.scala
@@ -86,12 +86,12 @@ object WebsiteUtils {
       s"https://img.shields.io/badge/Project%20Stage-${name.replace(" ", "%20") + '-' + color}.svg"
   }
   object ProjectStage {
-    final case object ProductionReady extends ProjectStage(name = "Production Ready", "brightgreen")
-    final case object Development     extends ProjectStage(name = "Development", "green")
-    final case object Experimental    extends ProjectStage(name = "Experimental", "yellowgreen")
-    final case object Research        extends ProjectStage(name = "Research", "yellow")
-    final case object Concept         extends ProjectStage(name = "Concept", "orange")
-    final case object Deprecated      extends ProjectStage(name = "Deprecated", "red")
+    case object ProductionReady extends ProjectStage(name = "Production Ready", "brightgreen")
+    case object Development     extends ProjectStage(name = "Development", "green")
+    case object Experimental    extends ProjectStage(name = "Experimental", "yellowgreen")
+    case object Research        extends ProjectStage(name = "Research", "yellow")
+    case object Concept         extends ProjectStage(name = "Concept", "orange")
+    case object Deprecated      extends ProjectStage(name = "Deprecated", "red")
   }
 
   def projectStageBadge(stage: ProjectStage): String =


### PR DESCRIPTION
## What

Updates sbt from `1.12.13` to **`2.0.2`** and migrates the whole plugin codebase to the sbt 2.x / Scala 3 API. This is the full migration behind the version bump — it supersedes #688 (the scala-steward version-only bump, which can't build on its own).

## Why the plugin now builds with Scala 3.8.4

sbt 2.0 compiles plugins with the Scala 3 version sbt itself is built with (3.8.4 for 2.0.1/2.0.2), so the plugin modules must use it to read sbt's TASTy. `zio-sbt-source` (a published 2.13/3.3 library) keeps its own Scala versions.

## Main changes

- **Cross-building:** replace portable-scala `sbt-crossproject` / `sbt-scalajs-crossproject` / `sbt-scala-native-crossproject` / `sbt-platform-deps` with [`sbt-uni-crossproject`](https://github.com/wvlet/sbt-uni-crossproject) — portable-scala has no sbt 2.0 release
- **Removed `sbt-explicit-dependencies`** (no sbt 2.0 release) and its `unusedCompileDependenciesFilter`
- **`CiTargetMap`:** rewritten without Scala 2 whitebox macros (dropped in Scala 3) — now plain functions over `Def.Initialize`
- **Task caching:** `build` wrapped in `Def.uncached` (sbt 2.0 caches task results)
- **API updates:** `Job.copy` → `withStrategy`/`withRunsOn`; `: _*` → `*`; `Setting[_]` → `Setting[?]`; `url(...)` → `uri(...)` (deprecated in 2.0.2); `buildInfoKeys` wrapped explicitly (Scala 3 dropped the implicit `SettingKey` → `BuildInfoKey` conversion)
- **Robustness:** tolerate a missing `ThisBuild / name` and a missing git repo at load time; anchor the generated website at `<base>/target/website`
- **scalafix:** the Scala 3 plugin modules run only the syntactic scalafix rules (`.scalafix-syntactic.conf`). The semantic rules (`OrganizeImports`, `RemoveUnused`, `Disable`, `ExplicitResultTypes`) need a SemanticDB + `-Wunused` wired through the shared `scalafixSettings`, which every downstream plugin user inherits — out of scope for a version bump. `zio-sbt-source` keeps the full semantic ruleset.

## Verification

Every CI job was reproduced locally on sbt **2.0.2**:

- **Build:** `+Test/compile`, `+publishLocal`, `docs/buildWebsite` ✅
- **Lint:** `lint` (scalafmt + scalafix), `ciCheckGithubWorkflow` (the generated `ci.yml` regenerates with no diff) ✅
- **Test:** `+test` (scripted) ✅

Supersedes #688 (scala-steward's version-only bump).
