### PR TITLE
Root-scope installWebsite output, don't wipe existing site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ target
 .vscode
 .metals
 metals.sbt
+/website/docs
+/website/build
+/website/node_modules
+/website/.docusaurus

--- a/zio-sbt-website/src/main/scala/zio/sbt/WebsitePlugin.scala
+++ b/zio-sbt-website/src/main/scala/zio/sbt/WebsitePlugin.scala
@@ -177,7 +177,12 @@ object WebsitePlugin extends sbt.AutoPlugin {
       val websiteDirPath = websiteDir.value
 
       if (Files.exists(websiteDirPath)) {
-        logger.warn(s"Website directory already exists, skipping installation: $websiteDirPath")
+        logger.warn(
+          s"""|
+              |Website directory already exists, skipping installation: $websiteDirPath
+              |Remove it manually and rerun installWebsite if you want a fresh install.
+              |""".stripMargin
+        )
       } else {
         val siteTarget = s"${target.value}/${normalizedName.value}-website"
 

--- a/zio-sbt-website/src/main/scala/zio/sbt/WebsitePlugin.scala
+++ b/zio-sbt-website/src/main/scala/zio/sbt/WebsitePlugin.scala
@@ -35,7 +35,7 @@ object WebsitePlugin extends sbt.AutoPlugin {
   object autoImport {
     val compileDocs: InputKey[Unit]                        = inputKey[Unit]("Compile docs")
     val installWebsite: TaskKey[Unit]                      = taskKey[Unit]("Install the website for the first time")
-    val buildWebsite: TaskKey[Unit]                        = taskKey[Unit]("Build website (default output: target/website/build)")
+    val buildWebsite: TaskKey[Unit]                        = taskKey[Unit]("Build website (default output: website/build)")
     val previewWebsite: TaskKey[Unit]                      = taskKey[Unit]("preview website")
     val publishToNpm: InputKey[Unit]                       = inputKey[Unit]("Publish website to the npm registry")
     val publishSnapshotToNpm: InputKey[Unit]               = inputKey[Unit]("Publish snapshot version of website to the npm registry")
@@ -82,7 +82,7 @@ object WebsitePlugin extends sbt.AutoPlugin {
   override lazy val projectSettings: Seq[Setting[_ <: Object]] =
     Seq(
       compileDocs          := compileDocsTask.evaluated,
-      websiteDir           := Paths.get(target.value.getPath, "website"),
+      websiteDir           := Paths.get((ThisBuild / baseDirectory).value.getPath, "website"),
       mdocOut              := websiteDir.value.resolve("docs").toFile,
       installWebsite       := installWebsiteTask.value,
       buildWebsite         := buildWebsiteTask.value,
@@ -176,46 +176,44 @@ object WebsitePlugin extends sbt.AutoPlugin {
 
       val websiteDirPath = websiteDir.value
 
-      // Always remove existing websiteDir to ensure a clean install.
-      // Without this, `mv` would move the new directory *into* the existing one
-      // as a subdirectory instead of replacing it.
       if (Files.exists(websiteDirPath)) {
-        logger.info(s"Removing existing website directory: $websiteDirPath")
-        exit(Process(s"rm ${websiteDirPath} -Rvf").!)
+        logger.warn(s"Website directory already exists, skipping installation: $websiteDirPath")
+      } else {
+        val siteTarget = s"${target.value}/${normalizedName.value}-website"
+
+        if (Files.exists(Paths.get(siteTarget)))
+          exit(Process(s"rm $siteTarget -Rvf").!)
+
+        val task: String =
+          s"""|npx @zio.dev/create-zio-website@${createZioWebsiteVersion.value} ${normalizedName.value}-website \\
+              |  --description="${name.value}" \\
+              |  --author="ZIO Contributors" \\
+              |  --email="email@zio.dev" \\
+              |  --license="Apache-2.0" \\
+              |  --architecture=Linux""".stripMargin
+
+        logger.info(s"installing website for ${normalizedName.value} ... \n$task")
+
+        exit(Process(task, target.value).!)
+
+        exit(Process(s"mv ${target.value}/${normalizedName.value}-website ${websiteDirPath}").!)
+
+        exit(s"rm -rvf ${websiteDirPath.toString}/.git/".!)
+
+        // Docusaurus 2.1.0 uses ProgressPlugin options removed in webpack >=5.76.
+        // Pin webpack to 5.75.0 via npm overrides and reinstall until Docusaurus is upgraded.
+        val pkgJsonFile    = new File(s"${websiteDirPath}/package.json")
+        val pkgJsonContent = IO.read(pkgJsonFile)
+        val patched        = pkgJsonContent.fromJson[Json.Obj] match {
+          case Right(obj) =>
+            Json.Obj(obj.fields :+ ("overrides" -> Json.Obj(Chunk("webpack" -> Json.Str("5.75.0"))))).toJsonPretty + "\n"
+          case Left(err) => sys.error(s"Failed to parse package.json: $err")
+        }
+        IO.write(pkgJsonFile, patched)
+        exit(Process("npm install", new File(s"${websiteDirPath}")).!)
+
+        val _ = Files.createDirectories(websiteDirPath.resolve("docs"))
       }
-
-      val siteTarget = s"${target.value}/${normalizedName.value}-website"
-
-      if (Files.exists(Paths.get(siteTarget)))
-        exit(Process(s"rm $siteTarget -Rvf").!)
-
-      val task: String =
-        s"""|npx @zio.dev/create-zio-website@${createZioWebsiteVersion.value} ${normalizedName.value}-website \\
-            |  --description="${name.value}" \\
-            |  --author="ZIO Contributors" \\
-            |  --email="email@zio.dev" \\
-            |  --license="Apache-2.0" \\
-            |  --architecture=Linux""".stripMargin
-
-      logger.info(s"installing website for ${normalizedName.value} ... \n$task")
-
-      exit(Process(task, target.value).!)
-
-      exit(Process(s"mv ${target.value}/${normalizedName.value}-website ${websiteDirPath}").!)
-
-      exit(s"rm -rvf ${websiteDirPath.toString}/.git/".!)
-
-      // Docusaurus 2.1.0 uses ProgressPlugin options removed in webpack >=5.76.
-      // Pin webpack to 5.75.0 via npm overrides and reinstall until Docusaurus is upgraded.
-      val pkgJsonFile    = new File(s"${websiteDirPath}/package.json")
-      val pkgJsonContent = IO.read(pkgJsonFile)
-      val patched        = pkgJsonContent.fromJson[Json.Obj] match {
-        case Right(obj) =>
-          Json.Obj(obj.fields :+ ("overrides" -> Json.Obj(Chunk("webpack" -> Json.Str("5.75.0"))))).toJsonPretty + "\n"
-        case Left(err) => sys.error(s"Failed to parse package.json: $err")
-      }
-      IO.write(pkgJsonFile, patched)
-      exit(Process("npm install", new File(s"${websiteDirPath}")).!)
     }
 
   lazy val buildWebsiteTask: Def.Initialize[Task[Unit]] =

--- a/zio-sbt-website/src/main/scala/zio/sbt/WebsitePlugin.scala
+++ b/zio-sbt-website/src/main/scala/zio/sbt/WebsitePlugin.scala
@@ -211,7 +211,9 @@ object WebsitePlugin extends sbt.AutoPlugin {
         val pkgJsonContent = IO.read(pkgJsonFile)
         val patched        = pkgJsonContent.fromJson[Json.Obj] match {
           case Right(obj) =>
-            Json.Obj(obj.fields :+ ("overrides" -> Json.Obj(Chunk("webpack" -> Json.Str("5.75.0"))))).toJsonPretty + "\n"
+            Json
+              .Obj(obj.fields :+ ("overrides" -> Json.Obj(Chunk("webpack" -> Json.Str("5.75.0")))))
+              .toJsonPretty + "\n"
           case Left(err) => sys.error(s"Failed to parse package.json: $err")
         }
         IO.write(pkgJsonFile, patched)

--- a/zio-sbt-website/src/main/scala/zio/sbt/WebsitePlugin.scala
+++ b/zio-sbt-website/src/main/scala/zio/sbt/WebsitePlugin.scala
@@ -211,9 +211,9 @@ object WebsitePlugin extends sbt.AutoPlugin {
         }
         IO.write(pkgJsonFile, patched)
         exit(Process("npm install", new File(s"${websiteDirPath}")).!)
-
-        val _ = Files.createDirectories(websiteDirPath.resolve("docs"))
       }
+
+      val _ = Files.createDirectories(websiteDirPath.resolve("docs"))
     }
 
   lazy val buildWebsiteTask: Def.Initialize[Task[Unit]] =

--- a/zio-sbt-website/src/sbt-test/zio-sbt-website/compileDocs/test
+++ b/zio-sbt-website/src/sbt-test/zio-sbt-website/compileDocs/test
@@ -1,8 +1,7 @@
 > clean
 > compile
 > compileDocs
-$ exists target/website/docs
-$ exists target/website/docs/index.md
-$ exists target/website/docs/package.json
-$ exists target/website/docs/sidebar.js
- 
+$ exists website/docs
+$ exists website/docs/index.md
+$ exists website/docs/package.json
+$ exists website/docs/sidebar.js

--- a/zio-sbt-website/src/sbt-test/zio-sbt-website/installWebsite/test
+++ b/zio-sbt-website/src/sbt-test/zio-sbt-website/installWebsite/test
@@ -1,11 +1,13 @@
 > clean
 > installWebsite
-$ exists target/website/src 
-$ exists target/website/static 
-$ exists target/website/LICENSE 
+$ exists website/src
+$ exists website/static
+$ exists website/LICENSE
 
-# Running installWebsite again should succeed (idempotent — removes and reinstalls)
+# Running installWebsite again should succeed and be a no-op: since the website
+# directory already exists, the task warns and skips scaffolding instead of
+# removing/reinstalling it.
 > installWebsite
-$ exists target/website/src 
-$ exists target/website/static 
-$ exists target/website/LICENSE 
+$ exists website/src
+$ exists website/static
+$ exists website/LICENSE


### PR DESCRIPTION
## Summary
- `websiteDir` now resolves to `<build root>/website` regardless of which project (root or a submodule like `docs`) runs the task, instead of the previous per-project `target/website`.
- `installWebsite` no longer deletes an existing `website` directory; it warns and skips scaffolding so committed site content survives a rerun.
- `installWebsite` always ensures `website/docs` exists as its last step (both on fresh install and on skip), matching `mdocOut`.
- `.gitignore` now only ignores the generated subpaths (`website/docs`, `website/build`, `website/node_modules`, `website/.docusaurus`) so the rest of the scaffolded site can be committed to the repo.

## Test plan
- [x] `sbt zio-sbt-website/compile`
- [x] `sbt docs/installWebsite` from a clean state — verified `website/docs` created
- [x] `sbt docs/installWebsite` re-run against an existing `website/` dir — verified it warns/skips scaffolding but still creates `website/docs`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>