### PR TITLE
fix(ci): add actions:write permission to auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -14,6 +14,7 @@ env: {}
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.run_id || github.ref }}
   cancel-in-progress: true

--- a/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
+++ b/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
@@ -658,7 +658,11 @@ object ZioSbtCiPlugin extends AutoPlugin {
     Workflow(
       name = "Auto-merge bot dependency PRs",
       triggers = dependencyBotPRTriggers,
-      permissions = Map("contents" -> "write", "pull-requests" -> "write"),
+      // "actions: write" is required for `gh pr merge --auto` to succeed on PRs that touch
+      // .github/workflows/**, per https://github.com/cli/cli/issues/11493 — GitHub's
+      // enablePullRequestAutoMerge mutation otherwise rejects with a "workflows permission"
+      // error, even though "workflows" isn't a valid permissions key at all.
+      permissions = Map("contents" -> "write", "pull-requests" -> "write", "actions" -> "write"),
       jobs = Seq(
         Job(
           id = "auto-merge",


### PR DESCRIPTION
## Summary

`auto-merge.yml`'s `gh pr merge --auto` was failing on dependency-bot PRs that touch `.github/workflows/**` (e.g. dependabot bumping an action version pin directly in a workflow file), with:

```
GraphQL: Pull request refusing to allow a GitHub App to create or update workflow `.github/workflows/ci.yml` without `workflows` permission (enablePullRequestAutoMerge)
```

Failing example: PR #694 ("Bump actions/setup-node from 6 to 7"), run https://github.com/zio/zio-sbt/actions/runs/30996029250/job/92273187845

### What was ruled out

- **Ruleset bypass for the `github-actions` app**: rejected outright by the API — `"Actor GitHub Actions integration must be part of the ruleset source or owner organization"`. The built-in Actions identity isn't an installable org App, so it's categorically ineligible as a bypass actor, via UI or API.
- Compared against `zio/zio` (no branch ruleset) and `zio/zio-http` (ruleset without a `pull_request` rule) — both succeed on identical dependabot workflow-file PRs; `zio-sbt`'s ruleset additionally enforces `pull_request`, which correlates with triggering this stricter check.

### The fix

Per [cli/cli#11493](https://github.com/cli/cli/issues/11493), multiple people hitting this exact error resolved it by adding `actions: write` to the workflow's `permissions:` block — despite `workflows` not being a valid `permissions` key at all (confirmed: using it directly errors with `Unexpected value 'workflows'`). Added `"actions" -> "write"` to `autoMergeWorkflow`'s permissions map in `ZioSbtCiPlugin.scala` and regenerated `auto-merge.yml`. `ci.yml` and `auto-approve.yml` are unaffected (verified identical).

Note from the linked thread: this fix has been reported as inconsistent by at least one user, so it's not a guaranteed 100% fix — but it's a one-line, no-new-secret change worth trying first.

## Test plan

- [x] `sbt zio-sbt-ci/compile` succeeds
- [x] `sbt ciGenerateGithubWorkflow` regenerates only `auto-merge.yml` (added `actions: write`); `ci.yml`/`auto-approve.yml` diff-clean
- [x] `sbt scalafmtAll` and `sbt lint` pass
- [ ] After merge: re-run `gh workflow run auto-merge.yml --repo zio/zio-sbt --ref main` and confirm PR #694 gets auto-merge enabled without the GraphQL error

🤖 Generated with [Claude Code](https://claude.com/claude-code)