### PR TITLE
Fix scmInfo browse URL for npm provenance verification

### DIFF
--- a/zio-sbt-ecosystem/src/main/scala/zio/sbt/ZioSbtEcosystemPlugin.scala
+++ b/zio-sbt-ecosystem/src/main/scala/zio/sbt/ZioSbtEcosystemPlugin.scala
@@ -120,8 +120,8 @@ object ZioSbtEcosystemPlugin extends AutoPlugin {
       normalizedName := (ThisBuild / name).value.toLowerCase.replaceAll(" ", "-"),
       scmInfo        := Some(
         ScmInfo(
-          homepage.value.get,
-          s"scm:git:git@github.com:zio/${normalizedName}.git"
+          url(s"https://github.com/zio/${normalizedName.value}"),
+          s"scm:git:git@github.com:zio/${normalizedName.value}.git"
         )
       ),
       pgpPassphrase        := sys.env.get("PGP_PASSPHRASE").map(_.toArray),


### PR DESCRIPTION
## Summary
- `ZioSbtEcosystemPlugin`'s `scmInfo` set `browseUrl` to the project `homepage` (`https://zio.dev/<name>`) instead of the actual GitHub repo URL. This bug existed since the plugin's original commit but was masked because `sbt-ci-release`'s bundled `GitPlugin` auto-derives `scmInfo` from `git remote origin` and took precedence (ThisBuild scope beats Global scope).
- `sbt-ci-release` was bumped `1.11.2 → 1.12.0` for the v0.6.1 release, changing that plugin's precedence behavior so it no longer overrides an already-set `scmInfo` — exposing the dormant bug. Verified by checking out v0.6.0 and v0.6.1 locally with a real GitHub remote: v0.6.0 resolved `scmInfo` to the correct GitHub URL, v0.6.1 resolved it to `https://zio.dev/zio-sbt`.
- Root cause of the `docs/publishToNpm` `E422` failures on the v0.6.1 and v0.6.2 releases: npm now enforces sigstore provenance, rejecting publishes where `package.json`'s `repository.url` doesn't match the GitHub repo attested by the GH Actions OIDC token.
- Also fixes the `scm:git:...` connection string, which interpolated the bare `normalizedName` `SettingKey` instead of `normalizedName.value`, producing a broken connection string like `scm:git:git@github.com:zio/SettingKey(...).git`.

## Test plan
- [x] `sbt zio-sbt-ecosystem/compile`
- [x] `sbt scalafmtCheckAll`
- [ ] Cut a release and confirm `Release Docs` / `docs/publishToNpm` succeeds

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>