### PR TITLE
fix: support docs/index.mdx in generateReadme and website badge substitution

### DIFF
--- a/zio-sbt-website/src/main/scala/zio/sbt/WebsitePlugin.scala
+++ b/zio-sbt-website/src/main/scala/zio/sbt/WebsitePlugin.scala
@@ -92,7 +92,19 @@ object WebsitePlugin extends sbt.AutoPlugin {
       publishHashverToNpm  := publishHashverToNpmTask.value,
       checkReadme          := checkReadmeTask.value,
       generateReadme       := generateReadmeTask.value,
-      docsDependencies     := Seq.empty,
+      // mdoc only treats "md" and "html" files as markdown by default, so without
+      // this, docs/index.mdx would be copied verbatim, leaving @VERSION@ and
+      // @PROJECT_BADGES@ unsubstituted. Passing the flag replaces the default
+      // list, so the defaults must be repeated here.
+      mdocExtraArguments ++= Seq(
+        "--markdown-extensions",
+        "md",
+        "--markdown-extensions",
+        "html",
+        "--markdown-extensions",
+        "mdx"
+      ),
+      docsDependencies := Seq.empty,
       libraryDependencies ++= docsDependencies.value,
       mdocVariables ++= {
         Map(
@@ -133,6 +145,14 @@ object WebsitePlugin extends sbt.AutoPlugin {
     )
 
   private def exit(exitCode: Int, errorMessage: String = "") = if (exitCode != 0) sys.error(errorMessage: String)
+
+  // Docs index may be either index.md or index.mdx (e.g. when the page needs
+  // JSX components like Tabs); mdoc preserves the extension on output.
+  private def resolveIndexFile(docsDir: Path): Path = {
+    val md  = docsDir.resolve("index.md")
+    val mdx = docsDir.resolve("index.mdx")
+    if (!Files.exists(md) && Files.exists(mdx)) mdx else md
+  }
 
   lazy val previewWebsiteTask: Def.Initialize[Task[Unit]] = Def.task {
     import zio.*
@@ -331,7 +351,7 @@ object WebsitePlugin extends sbt.AutoPlugin {
     }
 
   private def prefixUrlsWith(markdown: String, prefix: String): String = {
-    val regex = """\(((?!http)\S*\.(png|jpg|md|scala|java)\b)\)""".r
+    val regex = """\(((?!http)\S*\.(png|jpg|mdx?|scala|java)\b)\)""".r
 
     regex.replaceAllIn(markdown, '(' + prefix + _.group(1) + ')')
   }
@@ -367,14 +387,17 @@ object WebsitePlugin extends sbt.AutoPlugin {
   }
 
   lazy val ignoreIndexSnapshotVersion: Def.Initialize[Task[Unit]] = Def.task {
-    if (normalizedVersion.value.endsWith("-SNAPSHOT"))
-      exit("sed -i.bak s/@VERSION@/<version>/g docs/index.md".!)
+    if (normalizedVersion.value.endsWith("-SNAPSHOT")) {
+      val index = resolveIndexFile(Paths.get("docs"))
+      exit(s"sed -i.bak s/@VERSION@/<version>/g $index".!)
+    }
   }
 
   lazy val revertIndexChanges: Def.Initialize[Task[Unit]] = Def.task {
     if (normalizedVersion.value.endsWith("-SNAPSHOT")) {
-      exit("rm docs/index.md".!)
-      exit("mv docs/index.md.bak docs/index.md".!)
+      val index = resolveIndexFile(Paths.get("docs"))
+      exit(s"rm $index".!)
+      exit(s"mv $index.bak $index".!)
     }
   }
 
@@ -394,8 +417,9 @@ object WebsitePlugin extends sbt.AutoPlugin {
       Unsafe.unsafe { implicit unsafe =>
         Runtime.default.unsafe
           .run(
-            readFile(websiteDir.value.resolve("docs/index.md").toString).map(md => removeYamlHeader(md).trim).flatMap {
-              introduction =>
+            readFile(resolveIndexFile(websiteDir.value.resolve("docs")).toString)
+              .map(md => removeYamlHeader(md).trim)
+              .flatMap { introduction =>
                 WebsiteUtils.generateReadme(
                   projectName = projectName.value,
                   banner = readmeBanner.value,
@@ -409,7 +433,7 @@ object WebsitePlugin extends sbt.AutoPlugin {
                   credits = readmeCredits.value.trim,
                   maintainers = readmeMaintainers.value.trim
                 )
-            }
+              }
           )
           .getOrThrowFiberFailure()
       }

--- a/zio-sbt-website/src/main/scala/zio/sbt/WebsitePlugin.scala
+++ b/zio-sbt-website/src/main/scala/zio/sbt/WebsitePlugin.scala
@@ -92,17 +92,13 @@ object WebsitePlugin extends sbt.AutoPlugin {
       publishHashverToNpm  := publishHashverToNpmTask.value,
       checkReadme          := checkReadmeTask.value,
       generateReadme       := generateReadmeTask.value,
-      // mdoc only treats "md" and "html" files as markdown by default, so without
+      // mdoc only treats a limited set of extensions as markdown by default, so without
       // this, docs/index.mdx would be copied verbatim, leaving @VERSION@ and
-      // @PROJECT_BADGES@ unsubstituted. Passing the flag replaces the default
-      // list, so the defaults must be repeated here.
+      // @PROJECT_BADGES@ unsubstituted. `--markdown-extensions` expects a comma-separated
+      // list (and replaces the defaults), so include all desired extensions here.
       mdocExtraArguments ++= Seq(
         "--markdown-extensions",
-        "md",
-        "--markdown-extensions",
-        "html",
-        "--markdown-extensions",
-        "mdx"
+        "md,html,mdx"
       ),
       docsDependencies := Seq.empty,
       libraryDependencies ++= docsDependencies.value,

--- a/zio-sbt-website/src/sbt-test/zio-sbt-website/generateReadmeMdx/build.sbt
+++ b/zio-sbt-website/src/sbt-test/zio-sbt-website/generateReadmeMdx/build.sbt
@@ -1,0 +1,34 @@
+// The scripted sandbox is not a git repository, but loading this project
+// already evaluates docsVersion (which runs `git rev-parse HEAD`), and
+// generateReadme runs `git fetch --tags`. Initialize a repo with one commit
+// before the settings are evaluated, with the repo itself as remote so
+// fetching succeeds offline.
+val gitInit = {
+  import scala.sys.process._
+  if (!file(".git").exists()) {
+    Process(Seq("git", "init", ".")).!!
+    Process(Seq("git", "remote", "add", "origin", ".")).!!
+    Process(
+      Seq(
+        "git",
+        "-c",
+        "user.name=scripted",
+        "-c",
+        "user.email=scripted@example.com",
+        "commit",
+        "--allow-empty",
+        "-m",
+        "init"
+      )
+    ).!!
+  }
+}
+
+lazy val root = (project in file("."))
+  .settings(
+    version        := "0.1.0",
+    projectName    := "ZIO SBT",
+    mainModuleName := "test-project",
+    projectStage   := ProjectStage.ProductionReady
+  )
+  .enablePlugins(WebsitePlugin)

--- a/zio-sbt-website/src/sbt-test/zio-sbt-website/generateReadmeMdx/docs/index.mdx
+++ b/zio-sbt-website/src/sbt-test/zio-sbt-website/generateReadmeMdx/docs/index.mdx
@@ -1,0 +1,9 @@
+---
+id: index
+title: "Introduction to ZIO SBT"
+sidebar_label: "Introduction"
+---
+
+@PROJECT_BADGES@
+
+SBT Plugin for ZIO Projects, version @VERSION@.

--- a/zio-sbt-website/src/sbt-test/zio-sbt-website/generateReadmeMdx/project/plugins.sbt
+++ b/zio-sbt-website/src/sbt-test/zio-sbt-website/generateReadmeMdx/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("dev.zio" % "zio-sbt-website" % x)
+  case _       => sys.error("""|The system property 'plugin.version' is not defined.
+                               |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/zio-sbt-website/src/sbt-test/zio-sbt-website/generateReadmeMdx/test
+++ b/zio-sbt-website/src/sbt-test/zio-sbt-website/generateReadmeMdx/test
@@ -1,0 +1,15 @@
+# generateReadme must work when the docs index page is index.mdx instead of
+# index.md (https://github.com/zio/zio-sbt/issues/706).
+
+> generateReadme
+
+# mdoc preserves the .mdx extension on output and must substitute variables in it
+$ exists website/docs/index.mdx
+-$ exec grep -q @VERSION@ website/docs/index.mdx
+-$ exec grep -q @PROJECT_BADGES@ website/docs/index.mdx
+$ exec grep -q 0.1.0 website/docs/index.mdx
+
+# README.md is generated from the .mdx index with variables substituted
+$ exists README.md
+$ exec grep -q 0.1.0 README.md
+-$ exec grep -q @VERSION@ README.md


### PR DESCRIPTION
## Summary

Fixes #706.

`generateReadme` (and the website copy produced via mdoc) failed when a project's docs index page is `docs/index.mdx` instead of `docs/index.md` (e.g. zio-json, which needs `.mdx` for the `Tabs`/`TabItem` Scala 2/3 switcher):

- `generateReadmeTask` hardcoded `website/docs/index.md` and threw `FileNotFoundException`, so `README.md` silently stopped regenerating.
- mdoc only treats `md` and `html` files as markdown by default, so `index.mdx` was copied to `website/docs/index.mdx` verbatim, leaving literal `@PROJECT_BADGES@` / `@VERSION@` on the published site.

## Changes

- Resolve the docs index file as `index.md` with an `index.mdx` fallback in `generateReadmeTask`, `ignoreIndexSnapshotVersion`, and `revertIndexChanges`.
- Pass `--markdown-extensions md/html/mdx` to mdoc so `.mdx` files go through variable substitution instead of being copied verbatim. (The flag replaces mdoc's default list, so the defaults are repeated.)
- Include `.mdx` links in the README URL-prefixing regex.
- New scripted test `zio-sbt-website/generateReadmeMdx` covering the `.mdx` flow end to end: mdoc substitutes `@VERSION@`/`@PROJECT_BADGES@` in `website/docs/index.mdx`, and `README.md` is generated from it.

## Notes for reviewers

- The scripted test initializes a git repository from the sandbox's `build.sbt` (at project load) because `docsVersion` shells out to `git rev-parse HEAD` while settings are being evaluated, and `fetchLatestTag` needs a remote. This also surfaced two pre-existing issues, left out of scope here:
  - Loading any project with `WebsitePlugin` enabled in a non-git directory crashes with `Nonzero exit value: 128` (the `hashVersion` fallback of `docsVersion` uses `.!!` uncaught), which makes all existing `zio-sbt-website` scripted tests (`compileDocs`, `installWebsite`) fail when run locally.
  - CI's `sbt +test` does not appear to expand the `test -> scripted` command alias (the Test job finishes in ~85s with no scripted output), so scripted tests are currently not exercised on CI.

## Test plan

- `sbt "zio-sbt-website/scripted zio-sbt-website/generateReadmeMdx"` passes locally.
- `sbt lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)