### PR TITLE
fix: pass --markdown-extensions to mdoc as repeated flags

### DIFF
--- a/zio-sbt-website/src/main/scala/zio/sbt/WebsitePlugin.scala
+++ b/zio-sbt-website/src/main/scala/zio/sbt/WebsitePlugin.scala
@@ -99,11 +99,16 @@ object WebsitePlugin extends sbt.AutoPlugin {
       generateReadme       := generateReadmeTask.value,
       // mdoc only treats a limited set of extensions as markdown by default, so without
       // this, docs/index.mdx would be copied verbatim, leaving @VERSION@ and
-      // @PROJECT_BADGES@ unsubstituted. `--markdown-extensions` expects a comma-separated
-      // list (and replaces the defaults), so include all desired extensions here.
+      // @PROJECT_BADGES@ unsubstituted. `--markdown-extensions` replaces the defaults and
+      // must be passed once per extension (a comma-separated value is parsed as a single
+      // literal extension that matches no files), so include all desired extensions here.
       mdocExtraArguments ++= Seq(
         "--markdown-extensions",
-        "md,html,mdx"
+        "md",
+        "--markdown-extensions",
+        "html",
+        "--markdown-extensions",
+        "mdx"
       ),
       docsDependencies := Seq.empty,
       badgeArtifactId  := mainModuleName.value + '_' + scalaBinaryVersion.value,


### PR DESCRIPTION
## Summary

Fixes a regression on `main`: `mdocExtraArguments` currently passes `--markdown-extensions md,html,mdx` as a single value, but mdoc's CLI parser (metaconfig) does not split on commas — it treats the whole string as one literal extension named `md,html,mdx` that matches no files. As a result **every** markdown file, including plain `.md`, is copied verbatim, leaving `@VERSION@` and `@PROJECT_BADGES@` unsubstituted on the website and in the generated README.

The flag is repeated once per extension instead, which metaconfig accumulates into the intended list (`md`, `html`, `mdx`).

Verified empirically by rendering the website with both forms (comma form: literal `@PROJECT_BADGES@` on the page; repeated flags: substituted for both `.md` and `.mdx`).

## Test plan

- `sbt "zio-sbt-website/scripted zio-sbt-website/generateReadmeMdx"` passes — this scripted test asserts variable substitution and fails against current `main` (it isn't executed by CI today, see #709 / #711).
- `sbt lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)