### PR TITLE
fix: point javadoc badge at the published artifact coordinate

### DIFF
--- a/zio-sbt-website/src/main/scala/zio/sbt/WebsitePlugin.scala
+++ b/zio-sbt-website/src/main/scala/zio/sbt/WebsitePlugin.scala
@@ -118,7 +118,10 @@ object WebsitePlugin extends sbt.AutoPlugin {
               projectStage = projectStage.value,
               groupId = organization.value,
               artifactId = badgeArtifactId.value,
-              docsArtifactId = moduleName.value + '_' + scalaBinaryVersion.value,
+              // The javadoc badge must point at a published artifact. The docs module
+              // itself (moduleName here) is typically not published, so use the same
+              // published coordinate as the release badge.
+              docsArtifactId = badgeArtifactId.value,
               githubUser = "zio",
               githubRepo = scmInfo.value.map(_.browseUrl.getPath.split('/').last).getOrElse("github repo not provided"),
               projectName = projectName.value,


### PR DESCRIPTION
## Summary

The javadoc badge in `@PROJECT_BADGES@` is built from the docs module's own name (`moduleName + '_' + scalaBinaryVersion`, e.g. `dev.zio/zio-sbt-docs_2.12`). The docs module is typically not published to Maven Central, so both the badge image and its javadoc.io link 404 — including on this repo's own README.

This points the javadoc badge at `badgeArtifactId` instead: the same published coordinate the Sonatype release badge already uses, and which builds can override when needed (this repo overrides it to `zio-sbt-website_2.12_1.0` to account for the sbt cross-version suffix). `dev.zio/zio-sbt-website_2.12_1.0` publishes a `-javadoc.jar`, so javadoc.io can serve it.

Follow-up to #710.

## Test plan

- `sbt zio-sbt-website/compile` and `sbt zio-sbt-website/scalafmtCheck` pass.
- Verified `https://repo1.maven.org/maven2/dev/zio/zio-sbt-website_2.12_1.0/` exists and its releases include `-javadoc.jar`, while `dev/zio/zio-sbt-docs_2.12` returns 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)