### PR TITLE
Scope the workflow drift check to the workflow files

### DIFF
--- a/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
+++ b/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
@@ -803,16 +803,53 @@ object ZioSbtCiPlugin extends AutoPlugin {
     object HashVersioning     extends DocsVersioning("publishHashverToNpm")
   }
 
+  private val WorkflowsDir = ".github/workflows"
+
+  /** Runs git, returning its exit code and stdout lines. */
+  private def git(args: String*): (Int, Seq[String]) = {
+    val out  = scala.collection.mutable.ListBuffer.empty[String]
+    val code = Process("git" +: args) ! ProcessLogger(out += _, _ => ())
+    (code, out.toList)
+  }
+
   lazy val checkGithubWorkflowTask: Def.Initialize[Task[Unit]] =
     Def.task {
       val _ = ciGenerateGithubWorkflow.value
 
-      if ("git diff --exit-code".! == 1) {
+      // Regeneration has just overwritten the workflow files, so anything git still reports as
+      // changed is a difference between what the build produces and what was committed.
+      //
+      // The comparison is deliberately scoped to the workflow directory: a whole-tree `git diff`
+      // reports every unrelated edit in the working copy as workflow drift, which is a confusing
+      // failure for anyone running `sbt lint` locally with work in progress.
+      if (git("rev-parse", "--git-dir")._1 != 0)
         sys.error(
-          "The ci.yml workflow is not up-to-date!\n" +
-            "Please run `sbt ciGenerateGithubWorkflow` and commit new changes."
+          "`ciCheckGithubWorkflow` needs a git repository to compare the generated workflows " +
+            "against, and none was found."
         )
+
+      // Comparing against HEAD rather than the index, so a staged-but-uncommitted edit still counts.
+      // A repository with no commits yet has no HEAD; there everything is simply untracked.
+      val modified =
+        if (git("rev-parse", "--verify", "--quiet", "HEAD")._1 == 0)
+          git("diff", "--name-only", "HEAD", "--", WorkflowsDir) match {
+            case (0, files) => files
+            case (code, _)  => sys.error(s"`git diff` exited with $code; cannot verify the workflows.")
+          }
+        else Seq.empty
+
+      val untracked = git("ls-files", "--others", "--exclude-standard", "--", WorkflowsDir) match {
+        case (0, files) => files
+        case (code, _)  => sys.error(s"`git ls-files` exited with $code; cannot verify the workflows.")
       }
+
+      val stale = (modified ++ untracked).map(_.trim).filter(_.nonEmpty).distinct.sorted
+
+      if (stale.nonEmpty)
+        sys.error(
+          stale.mkString("These workflow files are not up to date:\n  ", "\n  ", "\n") +
+            "Please run `sbt ciGenerateGithubWorkflow` and commit the result."
+        )
     }
 
   def makePrefixJobs(backgroundJobs: Seq[String]): String =

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/driftCheck/build.sbt
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/driftCheck/build.sbt
@@ -1,0 +1,47 @@
+// `ciCheckGithubWorkflow` regenerates the workflows and then asks git whether the result differs
+// from what is committed.
+//
+// The comparison must be scoped to the workflow directory. It previously ran a whole-tree
+// `git diff`, so any unrelated edit in the working copy was reported as "the ci.yml workflow is not
+// up-to-date" - a misleading failure for anyone running `sbt lint` locally with work in progress.
+
+import scala.sys.process.Process
+
+ThisBuild / name := "Test Project"
+
+def run(dir: File, args: String*): Unit = {
+  val code = Process("git" +: args, dir).!
+  if (code != 0) sys.error(s"git ${args.mkString(" ")} failed with $code")
+}
+
+lazy val root = (project in file("."))
+  .settings(
+    version := "0.1",
+
+    // Scripted runs in a plain directory, so the repository has to be created here.
+    TaskKey[Unit]("gitInit") := {
+      val dir = baseDirectory.value
+      run(dir, "init", "-q", "-b", "main")
+      run(dir, "config", "user.email", "test@example.com")
+      run(dir, "config", "user.name", "Test")
+      run(dir, "add", "-A")
+      run(dir, "commit", "-q", "-m", "initial")
+    },
+
+    // An edit that has nothing to do with the workflows.
+    TaskKey[Unit]("dirtyUnrelated") := {
+      val dir = baseDirectory.value
+      IO.write(dir / "notes.md", "scratch\n")
+      run(dir, "add", "-A")
+    },
+
+    // A hand-edited workflow, committed. Committing matters: the check regenerates before
+    // comparing, so an uncommitted hand-edit is simply overwritten and there is nothing to detect.
+    TaskKey[Unit]("commitHandEdit") := {
+      val dir  = baseDirectory.value
+      val file = dir / ".github" / "workflows" / "ci.yml"
+      IO.write(file, IO.read(file) + "\n# hand-edited\n")
+      run(dir, "add", "-A")
+      run(dir, "commit", "-q", "-m", "hand-edit the generated workflow")
+    }
+  )

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/driftCheck/project/plugins.sbt
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/driftCheck/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("dev.zio" % "zio-sbt-ci" % x)
+  case _       => sys.error("""|The system property 'plugin.version' is not defined.
+                               |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/driftCheck/test
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/driftCheck/test
@@ -1,0 +1,15 @@
+# Generate the workflows, then commit them so there is a baseline to compare against.
+> ciGenerateGithubWorkflow
+> gitInit
+
+# A clean tree is up to date.
+> ciCheckGithubWorkflow
+
+# An unrelated edit is not workflow drift. This is the regression under test:
+# a whole-tree `git diff` used to fail here.
+> dirtyUnrelated
+> ciCheckGithubWorkflow
+
+# A committed hand-edit of a generated file is drift, and must be caught.
+> commitHandEdit
+-> ciCheckGithubWorkflow


### PR DESCRIPTION
`ciCheckGithubWorkflow` regenerates the workflows and then asks git whether anything changed — but
it asked with a whole-tree `git diff`, so any unrelated edit in the working copy was reported as:

```
The ci.yml workflow is not up-to-date!
Please run `sbt ciGenerateGithubWorkflow` and commit new changes.
```

That misfires constantly. Running `sbt lint` locally with work in progress, or with a build file
scalafmt just reformatted, fails with a message about workflow drift while `.github/workflows` is
untouched. It happened four times while migrating zio-blocks to this plugin, each time pointing the
reader at the wrong files.

## Also fixed

| Problem | Consequence |
|---|---|
| `git diff` compares working tree to index | a **staged** but uncommitted workflow edit was invisible |
| untracked files were never consulted | a workflow the build should have generated but did not was reported as up to date |
| only exit code 1 counted as a difference | exit 128 — no git repository, or git missing — silently **passed** |

The check now compares against `HEAD`, scoped to `.github/workflows`; additionally lists untracked
files there; fails loudly when git cannot answer; and names the files it found instead of always
blaming `ci.yml`.

## Tests

New `driftCheck` fixture, covering all three behaviours:

- clean tree → passes
- unrelated dirty file → passes ← **the regression**
- committed hand-edit of a generated workflow → fails

The last case has to commit the hand-edit. The check regenerates before comparing, so an
uncommitted edit is simply overwritten and there is nothing left to detect — a fixture that skipped
the commit would pass while asserting nothing.

All 11 scripted fixtures pass; `sbt lint` clean.

## Why it matters now

zio/zio-blocks#1567 adds `sbt ciCheckGithubWorkflow` to its lint job, so this check is about to
start gating a real repository's CI. It should stop reporting unrelated edits as workflow drift
before it does.