### PR TITLE
Write workflows relative to the build, and slugify the file name

### DIFF
--- a/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
+++ b/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
@@ -584,8 +584,24 @@ object ZioSbtCiPlugin extends AutoPlugin {
         |$yaml""".stripMargin
   }
 
+  /**
+   * Turns a workflow name into a file name.
+   *
+   * Anything that is not alphanumeric becomes a dash, so a name like
+   * "Continuous Integration" yields `continuous-integration.yml` rather than a
+   * file with a space in it.
+   */
+  private[sbt] def workflowFileName(workflowName: String): String = {
+    val slug = workflowName.trim.toLowerCase.replaceAll("[^a-z0-9]+", "-").replaceAll("(^-)|(-$)", "")
+    s"${if (slug.isEmpty) "ci" else slug}.yml"
+  }
+
+  def writeWorkflowFile(baseDir: File, workflow: Workflow, fileName: String): Unit =
+    IO.write(baseDir / ".github" / "workflows" / fileName, renderWorkflow(workflow))
+
+  @deprecated("Use the overload taking the build's base directory", "0.6.4")
   def writeWorkflowFile(workflow: Workflow, fileName: String): Unit =
-    IO.write(new File(s".github/workflows/$fileName"), renderWorkflow(workflow))
+    writeWorkflowFile(file("."), workflow, fileName)
 
   lazy val generateGithubWorkflowTask: Def.Initialize[Task[Unit]] =
     Def.task {
@@ -615,7 +631,7 @@ object ZioSbtCiPlugin extends AutoPlugin {
           buildJobs ++ lintJobs ++ testJobs ++ updateReadmeJobs ++ reportSuccessful ++ releaseJobs ++ postReleaseJobs
       )
 
-      writeWorkflowFile(workflow, s"${workflowName.toLowerCase}.yml")
+      writeWorkflowFile((ThisBuild / Keys.baseDirectory).value, workflow, workflowFileName(workflowName))
     }
 
   private def dependencyBotPRCondition(bots: Seq[String]): Condition = {
@@ -717,10 +733,10 @@ object ZioSbtCiPlugin extends AutoPlugin {
   }
 
   lazy val generateAutoApproveWorkflowTask: Def.Initialize[Task[Unit]] =
-    Def.task(writeWorkflowFile(autoApproveWorkflow.value, "auto-approve.yml"))
+    Def.task(writeWorkflowFile((ThisBuild / Keys.baseDirectory).value, autoApproveWorkflow.value, "auto-approve.yml"))
 
   lazy val generateAutoMergeWorkflowTask: Def.Initialize[Task[Unit]] =
-    Def.task(writeWorkflowFile(autoMergeWorkflow.value, "auto-merge.yml"))
+    Def.task(writeWorkflowFile((ThisBuild / Keys.baseDirectory).value, autoMergeWorkflow.value, "auto-merge.yml"))
 
   override lazy val buildSettings: Seq[Setting[_]] =
     Seq(

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowTitle/build.sbt
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowTitle/build.sbt
@@ -1,0 +1,22 @@
+// A workflow name is also the file name, so it has to be slugified: "Continuous Integration" must
+// not produce a file with a space in it.
+//
+// The generated file is written relative to the build's base directory rather than the working
+// directory, so `sbt ciGenerateGithubWorkflow` from a subdirectory still writes to the right place.
+
+ThisBuild / name := "Test Project"
+
+inThisBuild(List(ciWorkflowTitle := "Continuous Integration"))
+
+lazy val root = (project in file("."))
+  .settings(
+    version := "0.1",
+    TaskKey[Unit]("checkFileName") := {
+      val dir      = baseDirectory.value / ".github" / "workflows"
+      val expected = dir / "continuous-integration.yml"
+      if (!expected.exists)
+        sys.error(s"expected $expected, found: ${IO.listFiles(dir).map(_.getName).sorted.mkString(", ")}")
+      if (!IO.read(expected).contains("name: Continuous Integration"))
+        sys.error("the workflow name inside the file should be unchanged")
+    }
+  )

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowTitle/build.sbt
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowTitle/build.sbt
@@ -14,8 +14,10 @@ lazy val root = (project in file("."))
     TaskKey[Unit]("checkFileName") := {
       val dir      = baseDirectory.value / ".github" / "workflows"
       val expected = dir / "continuous-integration.yml"
-      if (!expected.exists)
-        sys.error(s"expected $expected, found: ${IO.listFiles(dir).map(_.getName).sorted.mkString(", ")}")
+      if (!expected.exists) {
+        val found = if (dir.exists) IO.listFiles(dir).map(_.getName).sorted.mkString(", ") else "<dir missing>"
+        sys.error(s"expected $expected, found: $found")
+      }
       if (!IO.read(expected).contains("name: Continuous Integration"))
         sys.error("the workflow name inside the file should be unchanged")
     }

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowTitle/project/plugins.sbt
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowTitle/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("dev.zio" % "zio-sbt-ci" % x)
+  case _       => sys.error("""|The system property 'plugin.version' is not defined.
+                               |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowTitle/test
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowTitle/test
@@ -1,0 +1,3 @@
+# The file name is slugified from the workflow name.
+> ciGenerateGithubWorkflow
+> checkFileName


### PR DESCRIPTION
Two problems with **where** the generated workflows land and **what** they are called.

## Path

`writeWorkflowFile` wrote to a path relative to the JVM's working directory:

```scala
IO.write(new File(s".github/workflows/$fileName"), renderWorkflow(workflow))
```

Run `sbt ciGenerateGithubWorkflow` from anywhere other than the repository root and it creates a
stray `.github/workflows` under whatever directory sbt was started in, while the real one silently
goes unchanged. It now writes relative to the build's base directory.

The old two-argument signature is public API — a build could be calling it to emit an extra
workflow — so it is kept and `@deprecated`, delegating to the new one.

## File name

The file name was the workflow name lowercased, so a `ciWorkflowTitle` of `"Continuous Integration"`
produced a file with a space in it. Runs of non-alphanumeric characters now become dashes:

| `ciWorkflowTitle` | before | after |
| --- | --- | --- |
| `"CI"` | `ci.yml` | `ci.yml` |
| `"Continuous Integration"` | `continuous integration.yml` | `continuous-integration.yml` |

The workflow's own `name:` is untouched — only the file name is slugified.

## Compatibility

Neither change moves an existing workflow:

- everyone invokes sbt from the repository root, where old and new paths agree
- slugification only affects names containing characters outside `[a-z0-9]`, and the default `"CI"`
  does not

This is also the right moment for the naming fix. `ciWorkflowTitle` was introduced in #716 and no
repository sets it yet, so slugifying cannot orphan anyone's existing file. Had this been done
before that rename it would have been breaking — `zio-http` sets `ciWorkflowName := "Continuous
Integration"`, which now belongs to zio-sbt-website and controls only the README badge.

## Tests

New `workflowTitle` fixture asserts the slugified file name exists and that `name: Continuous
Integration` inside it is unchanged.

All 12 scripted fixtures pass; `sbt lint` and `sbt ciCheckGithubWorkflow` clean.