### PR TITLE
Fix main: stale golden after #721, and setup-node pin out of sync after #694

### DIFF
--- a/zio-sbt-ci/src/main/scala/zio/sbt/V.scala
+++ b/zio-sbt-ci/src/main/scala/zio/sbt/V.scala
@@ -9,7 +9,7 @@ object V {
       "actions/checkout"                -> "v7",
       "coursier/cache-action"           -> "v8",
       "actions/setup-java"              -> "v5",
-      "actions/setup-node"              -> "v6",
+      "actions/setup-node"              -> "v7",
       "sbt/setup-sbt"                   -> "v1"
     ).map { case (k, v) => (k, s"$k@$v") }.apply(packageName)
 }

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/bothPlugins/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/bothPlugins/expected/ci.yml
@@ -233,7 +233,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8
     - name: Setup NodeJs
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: 24.12.0
         registry-url: https://registry.npmjs.org

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/concurrency/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/concurrency/expected/ci.yml
@@ -227,7 +227,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8
     - name: Setup NodeJs
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: 24.12.0
         registry-url: https://registry.npmjs.org

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/customJobs/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/customJobs/expected/ci.yml
@@ -245,7 +245,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8
     - name: Setup NodeJs
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: 24.12.0
         registry-url: https://registry.npmjs.org

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/defaults/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/defaults/expected/ci.yml
@@ -233,7 +233,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8
     - name: Setup NodeJs
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: 24.12.0
         registry-url: https://registry.npmjs.org

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/flattenTests/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/flattenTests/expected/ci.yml
@@ -237,7 +237,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8
     - name: Setup NodeJs
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: 24.12.0
         registry-url: https://registry.npmjs.org

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/groupTests/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/groupTests/expected/ci.yml
@@ -248,7 +248,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8
     - name: Setup NodeJs
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: 24.12.0
         registry-url: https://registry.npmjs.org

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/mappedJobs/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/mappedJobs/expected/ci.yml
@@ -259,7 +259,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8
     - name: Setup NodeJs
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: 24.12.0
         registry-url: https://registry.npmjs.org

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/services/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/services/expected/ci.yml
@@ -239,7 +239,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8
     - name: Setup NodeJs
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: 24.12.0
         registry-url: https://registry.npmjs.org

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/settingsOverrides/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/settingsOverrides/expected/ci.yml
@@ -236,7 +236,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8
     - name: Setup NodeJs
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: 24.12.0
         registry-url: https://registry.npmjs.org

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowEnv/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowEnv/expected/ci.yml
@@ -233,7 +233,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8
     - name: Setup NodeJs
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: 24.12.0
         registry-url: https://registry.npmjs.org

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowTriggers/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowTriggers/expected/ci.yml
@@ -232,7 +232,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8
     - name: Setup NodeJs
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: 24.12.0
         registry-url: https://registry.npmjs.org

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowTriggers/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowTriggers/expected/ci.yml
@@ -148,6 +148,7 @@ jobs:
             - After each release, I will update the version in the installation section.
             - After any changes to the "docs/index.md" file, I will update the README.md file accordingly.
         branch: zio-sbt-website/update-readme
+        base: ${{ github.event.repository.default_branch }}
         commit-message: Update README.md
         token: ${{ steps.generate-token.outputs.token }}
         delete-branch: true


### PR DESCRIPTION
**main is red.** Two independent causes, both semantic conflicts between pull requests that never
conflicted textually and were each green on their own branch.

## 1. Stale golden after #721

- **#721** added `base: ${{ github.event.repository.default_branch }}` to the `create-pull-request`
  step in `updateReadmeJobs`
- **#722** added the `workflowTriggers` fixture, whose golden was recorded *before* #721 existed

Different files, no merge conflict — but the combination is stale, so the fixture fails on main.
Re-recorded; one line.

## 2. setup-node pin out of sync after #694

- **#694** bumped `actions/setup-node` from v6 to v7 **in `.github/workflows/ci.yml`**
- that file is generated from `V.scala`, which still said v6

So the generator and the committed workflow disagreed, and `ciCheckGithubWorkflow` failed on every
subsequent pull request:

```
These workflow files are not up to date:
  .github/workflows/ci.yml
```

Fixed by bumping `V.scala`, not by reverting the workflow — v7 is what the update intended. The
eleven goldens that pin the action are updated to match, each the same single line:

```diff
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
```

I patched that one line rather than re-recording the files wholesale, so the diff is provably
minimal; the fixtures passing is what confirms the result matches generated output rather than
having been edited into some other shape.

## A standing problem worth deciding on

Cause 2 is not a one-off. Dependabot's `github-actions` ecosystem edits `.github/workflows`
directly, but in this repository those files are **generated**. Every future action bump will red
main the same way until someone mirrors the pin into `V.scala`.

Two ways out, both outside this PR:

- exclude the generated workflows from Dependabot, and bump the pins in `V.scala` instead
- accept that each bump needs a paired source change, and expect the drift check to catch it

The drift check is doing its job here — it caught both problems on the first run after the merge.
But it catches them *after* landing. Rebasing a workflow-affecting PR on main immediately before
merge would surface this class of conflict earlier.

## Verification

All 13 fixtures pass; `sbt lint` and `sbt ciCheckGithubWorkflow` clean.