### PR TITLE
Use real job ids in the ci gate, and honour ciTargetJavaVersions

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ All settings are `ThisBuild`-scoped.
 | `ciUpdateReadmeJobs` | `Seq[Job]` | one `update-readme` job | Set to `Seq.empty` if the README is maintained by hand |
 | `ciReleaseJobs` | `Seq[Job]` | one `release` job | |
 | `ciPostReleaseJobs` | `Seq[Job]` | `release-docs`, `notify-docs-release` | |
-| `ciPullRequestApprovalJobs` | `Seq[String]` | `lint`, `test`, `build` | Job ids the aggregate `ci` job waits on. Update this when renaming or adding jobs |
+| `ciPullRequestApprovalJobs` | `Seq[String]` | the ids of `ciLintJobs`, `ciTestJobs` and `ciBuildJobs` | Job ids the aggregate `ci` job waits on. Follows the jobs those three settings produce, so renaming or adding one is picked up without touching this |
 | `ciReleaseApprovalJobs` | `Seq[String]` | `Seq("ci")` | Job ids the release waits on |
 | `ciCheckArtifactsCompilationSteps` | `Seq[Step]` | `sbt +Test/compile` | |
 | `ciCheckArtifactsBuildSteps` | `Seq[Step]` | `sbt +publishLocal` | |
@@ -281,9 +281,14 @@ ciTestJobs := Seq(
     )
   )
 )
+```
 
-// The aggregate `ci` job waits on job ids, so keep it in step:
-ciPullRequestApprovalJobs := Seq("lint", "build", "integration-test")
+The aggregate `ci` job waits on the ids of whatever `ciLintJobs`, `ciTestJobs` and `ciBuildJobs`
+produce, so replacing `test` with `integration-test` above is enough on its own. Set
+`ciPullRequestApprovalJobs` only to wait on a different set than those three:
+
+```scala
+ciPullRequestApprovalJobs := Seq("lint", "integration-test")
 ```
 
 `Checkout`, `SetupLibuv`, `SetupJava(version)`, `SetupSBT`, `CacheDependencies`, `SetupNodeJs` and `SetSwapSpace` are all available; the ones defined as settings need `.value`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -215,7 +215,7 @@ All settings are `ThisBuild`-scoped.
 | `ciUpdateReadmeJobs` | `Seq[Job]` | one `update-readme` job | Set to `Seq.empty` if the README is maintained by hand |
 | `ciReleaseJobs` | `Seq[Job]` | one `release` job | |
 | `ciPostReleaseJobs` | `Seq[Job]` | `release-docs`, `notify-docs-release` | |
-| `ciPullRequestApprovalJobs` | `Seq[String]` | `lint`, `test`, `build` | Job ids the aggregate `ci` job waits on. Update this when renaming or adding jobs |
+| `ciPullRequestApprovalJobs` | `Seq[String]` | the ids of `ciLintJobs`, `ciTestJobs` and `ciBuildJobs` | Job ids the aggregate `ci` job waits on. Follows the jobs those three settings produce, so renaming or adding one is picked up without touching this |
 | `ciReleaseApprovalJobs` | `Seq[String]` | `Seq("ci")` | Job ids the release waits on |
 | `ciCheckArtifactsCompilationSteps` | `Seq[Step]` | `sbt +Test/compile` | |
 | `ciCheckArtifactsBuildSteps` | `Seq[Step]` | `sbt +publishLocal` | |
@@ -280,9 +280,14 @@ ciTestJobs := Seq(
     )
   )
 )
+```
 
-// The aggregate `ci` job waits on job ids, so keep it in step:
-ciPullRequestApprovalJobs := Seq("lint", "build", "integration-test")
+The aggregate `ci` job waits on the ids of whatever `ciLintJobs`, `ciTestJobs` and `ciBuildJobs`
+produce, so replacing `test` with `integration-test` above is enough on its own. Set
+`ciPullRequestApprovalJobs` only to wait on a different set than those three:
+
+```scala
+ciPullRequestApprovalJobs := Seq("lint", "integration-test")
 ```
 
 `Checkout`, `SetupLibuv`, `SetupJava(version)`, `SetupSBT`, `CacheDependencies`, `SetupNodeJs` and `SetSwapSpace` are all available; the ones defined as settings need `.value`.

--- a/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
+++ b/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
@@ -232,7 +232,7 @@ object ZioSbtCiPlugin extends AutoPlugin {
                   }
                 } else {
                   (for {
-                    javaPlatform: String <- Set("17", "21", "25")
+                    javaPlatform: String <- javaPlatforms
                     scalaVersion: String <- scalaVersionMatrix.values.toSeq.flatten.toSet
                     projects              =
                       scalaVersionMatrix.filterKeys { p =>
@@ -306,29 +306,15 @@ object ZioSbtCiPlugin extends AutoPlugin {
               )
             } else {
               Step.StepSequence(
-                Seq(
+                javaPlatforms.map { javaPlatform =>
                   Step.SingleStep(
-                    name = "Java 17 Tests",
-                    condition = Some(Condition.Expression("matrix.java == '17'")),
+                    name = s"Java $javaPlatform Tests",
+                    condition = Some(Condition.Expression(s"matrix.java == '$javaPlatform'")),
                     run = Some(
-                      prefixJobs + "sbt ${{ matrix.scala-project-java17 }}/test"
-                    )
-                  ),
-                  Step.SingleStep(
-                    name = "Java 21 Tests",
-                    condition = Some(Condition.Expression("matrix.java == '21'")),
-                    run = Some(
-                      prefixJobs + "sbt ${{ matrix.scala-project-java21 }}/test"
-                    )
-                  ),
-                  Step.SingleStep(
-                    name = "Java 25 Tests",
-                    condition = Some(Condition.Expression("matrix.java == '25'")),
-                    run = Some(
-                      prefixJobs + "sbt ${{ matrix.scala-project-java25 }}/test"
+                      prefixJobs + s"sbt $${{ matrix.scala-project-java$javaPlatform }}/test"
                     )
                   )
-                )
+                }
               )
 
             }
@@ -828,8 +814,9 @@ object ZioSbtCiPlugin extends AutoPlugin {
       ciReleaseJobs             := releaseJobs.value,
       ciPostReleaseJobs         := postReleaseJobs.value,
       ciPullRequestApprovalJobs := Def.setting {
-        val test = ciTestJobs.value.map(_ => "test")
-        Seq("lint") ++ test ++ Seq("build")
+        // The real job ids: a build that renames a job, or adds a second test job, needs the
+        // aggregate job to wait on what actually exists.
+        ciLintJobs.value.map(_.id) ++ ciTestJobs.value.map(_.id) ++ ciBuildJobs.value.map(_.id)
       }.value,
       ciReleaseApprovalJobs := Seq("ci")
     )

--- a/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
+++ b/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
@@ -205,7 +205,7 @@ object ZioSbtCiPlugin extends AutoPlugin {
           Strategy(
             matrix = Map(
               "java"  -> javaPlatforms.toList,
-              "scala" -> scalaVersionMatrix.values.flatten.toSet.toList
+              "scala" -> scalaVersionMatrix.values.toSeq.flatten.distinct.toList
             ),
             maxParallel = matrixMaxParallel,
             failFast = false
@@ -233,7 +233,7 @@ object ZioSbtCiPlugin extends AutoPlugin {
                 } else {
                   (for {
                     javaPlatform: String <- javaPlatforms
-                    scalaVersion: String <- scalaVersionMatrix.values.toSeq.flatten.toSet
+                    scalaVersion: String <- scalaVersionMatrix.values.toSeq.flatten.distinct
                     projects              =
                       scalaVersionMatrix.filterKeys { p =>
                         javaPlatformMatrix.getOrElse(p, javaPlatform).toInt <= javaPlatform.toInt

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/groupTests/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/groupTests/expected/ci.yml
@@ -106,17 +106,11 @@ jobs:
       if: ${{ (matrix.java == '17') && (matrix.scala == '2.13.16') }}
       run: 'sbt ++${{ matrix.scala }} moduleA/test '
     - name: Test
-      if: ${{ (matrix.java == '25') && (matrix.scala == '2.13.16') }}
+      if: ${{ (matrix.java == '21') && (matrix.scala == '2.13.16') }}
       run: 'sbt ++${{ matrix.scala }} moduleA/test  moduleB/test '
     - name: Test
       if: ${{ (matrix.java == '21') && (matrix.scala == '3.3.4') }}
       run: 'sbt ++${{ matrix.scala }} moduleB/test '
-    - name: Test
-      if: ${{ (matrix.java == '25') && (matrix.scala == '3.3.4') }}
-      run: 'sbt ++${{ matrix.scala }} moduleB/test '
-    - name: Test
-      if: ${{ (matrix.java == '21') && (matrix.scala == '2.13.16') }}
-      run: 'sbt ++${{ matrix.scala }} moduleA/test  moduleB/test '
   update-readme:
     name: Update README
     runs-on: ubuntu-latest

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/mappedJobs/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/mappedJobs/expected/ci.yml
@@ -198,7 +198,7 @@ jobs:
     needs:
     - lint
     - test
-    - test
+    - compile-examples
     - build
     steps:
     - name: Report Successful CI


### PR DESCRIPTION
Two defects that only surface once a build moves off the defaults. Both silently produce a workflow
that does less than it appears to — no error, no warning, just checks that never run.

## 1. The `ci` gate waited on a literal, not the real jobs

```scala
val test = ciTestJobs.value.map(_ => "test")
Seq("lint") ++ test ++ Seq("build")
```

One test job happens to give the right answer. **Two gives `needs: [lint, test, test, build]`** —
the second job is never waited on, so the aggregate gate can pass while it is still running or has
already failed. Since `ci` is the job branch protection points at, that is a gate with a hole in it.

`zio-logging` appends a `compile-examples` job and is in exactly this position today.

Now the real ids are used:

```scala
ciLintJobs.value.map(_.id) ++ ciTestJobs.value.map(_.id) ++ ciBuildJobs.value.map(_.id)
```

## 2. The test strategies ignored `ciTargetJavaVersions`

`GroupTests` iterated a hard-coded `Set("17", "21", "25")`, and `FlattenTests` emitted one step per
hard-coded version referencing matrix keys like `scala-project-java25`.

The matrix itself was **already** built from `ciTargetJavaVersions`, so the two disagreed. A build
narrowing to 17 and 21 got steps conditioned on a version absent from its matrix, referencing a key
that does not exist. Those steps never ran, and nothing said so.

Both paths now use the configured versions. Iterating the setting's `Seq` rather than a `Set` also
removes a latent nondeterminism in generated output — worth having where golden files compare byte
for byte.

## What moves

Two goldens, each showing the defect being removed:

| Fixture | Change |
| --- | --- |
| `groupTests` | the two `matrix.java == '25'` steps disappear — matrix is `['17','21']`, they were unreachable |
| `mappedJobs` | `needs: [lint, test, test, build]` → `[lint, test, compile-examples, build]` |

The other eleven fixtures are untouched. An adopter that sets neither a second test job nor a
non-default `ciTargetJavaVersions` sees no change.

## For the release notes

`zio-logging`'s `ci` job gains `compile-examples` as a dependency. That is the fix working — the job
was always meant to gate on it — but it does mean a check that previously could pass without waiting
now waits.

## Verification

All 13 fixtures pass; `sbt lint` and `sbt ciCheckGithubWorkflow` clean; compiles under
`enableStrictCompile`.