### PR TITLE
Revert "Update sbt to 2.0.6" — main cannot load

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=2.0.6
+sbt.version=1.12.15


### PR DESCRIPTION
**`main` is currently unloadable.** Nothing can be built, tested or released.

#726 set `sbt.version` to 2.0.6, but the plugins in `project/plugins.sbt` have no sbt 2 builds, so
resolution fails before the build is loaded at all:

```
Error downloading org.portable-scala:sbt-scalajs-crossproject_sbt2_3:1.3.2
  Not found
  not found: https://repo1.maven.org/maven2/org/portable-scala/sbt-scalajs-crossproject_sbt2_3/1.3.2/...
```

This restores `sbt.version=1.12.15`. Migrating to sbt 2 requires moving the plugins over as well —
which is what #684, #689 and #699 are for. It is not a one-line version bump.

Verified on this branch: build loads, `sbt lint` clean, `sbt ciCheckGithubWorkflow` clean, all 13
scripted fixtures pass.

## How this landed, because it will happen again

Every real check on #726 failed:

| Check | Result |
| --- | --- |
| Build | **failure** |
| Lint | **failure** |
| Test (17) | **failure** |
| Test (21) | **failure** |
| Test (25) | **failure** |
| `ci` | *skipped* |

It was auto-approved and auto-merged regardless.

`ci` is the **only** required status check on `main`. It declares `needs: [lint, test, build]`
without `if: always()`, so when those failed it was **skipped rather than run** — and
[GitHub reports a job skipped by a conditional as a success](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks)
to branch protection.

So the single required check passed *because* everything it guards had failed. The gate is inverted:
it protects only while nothing is wrong.

This is the second time — #694 merged the same way with a red `Lint`, which is what left `main`'s
generated `ci.yml` out of sync with `V.scala` and required #724 to fix.

A follow-up change to the generated `ci` job (`if: always()` plus a step that fails when any
dependency did not succeed) closes this properly, and benefits every repository using the plugin.
I would suggest landing that before the next dependency bump arrives.

Two related observations while verifying, neither the cause here:

- `enforce_admins` is `false` on `main`.
- The `main` ruleset has two Integration bypass actors with `bypass_mode: always` (app ids `29110`,
  `314572`) — worth a look, though classic protection still applied in this case.