### PR TITLE
Make the ci gate fail instead of skip when a job fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,11 @@ jobs:
     - lint
     - test
     - build
+    if: always()
     steps:
+    - name: Report Failed CI
+      if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+      run: 'echo "ci failed: one or more required jobs did not succeed"; exit 1'
     - name: Report Successful CI
       run: echo "ci passed"
   release:

--- a/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
+++ b/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
@@ -360,7 +360,26 @@ object ZioSbtCiPlugin extends AutoPlugin {
         id = "ci",
         name = "ci",
         need = pullRequestApprovalJobs,
+        // Runs even when a job it needs has failed.
+        //
+        // Without this the job is skipped, and GitHub reports a skipped job to branch protection as
+        // a success. Since this is the job repositories are told to require, the single required
+        // check would pass precisely when something upstream had broken - and a pull request with a
+        // failing lint or test job would merge. That is not hypothetical: it is how #694 landed on
+        // main with a red Lint job.
+        condition = Some(Condition.Function("always()")),
         steps = Seq(
+          // Only `failure` and `cancelled` count. An upstream job that was skipped was usually
+          // skipped on purpose, by its own condition, and should not fail the gate.
+          SingleStep(
+            name = "Report Failed CI",
+            condition = Some(
+              Condition.Expression(
+                "contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')"
+              )
+            ),
+            run = Some("echo \"ci failed: one or more required jobs did not succeed\"; exit 1")
+          ),
           SingleStep(
             name = "Report Successful CI",
             run = Some("echo \"ci passed\"")

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/bothPlugins/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/bothPlugins/expected/ci.yml
@@ -174,7 +174,11 @@ jobs:
     - lint
     - test
     - build
+    if: always()
     steps:
+    - name: Report Failed CI
+      if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+      run: 'echo "ci failed: one or more required jobs did not succeed"; exit 1'
     - name: Report Successful CI
       run: echo "ci passed"
   release:

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/concurrency/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/concurrency/expected/ci.yml
@@ -174,7 +174,11 @@ jobs:
     - lint
     - test
     - build
+    if: always()
     steps:
+    - name: Report Failed CI
+      if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+      run: 'echo "ci failed: one or more required jobs did not succeed"; exit 1'
     - name: Report Successful CI
       run: echo "ci passed"
   release:

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/customJobs/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/customJobs/expected/ci.yml
@@ -178,7 +178,11 @@ jobs:
     - lint
     - compile
     - integration-test
+    if: always()
     steps:
+    - name: Report Failed CI
+      if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+      run: 'echo "ci failed: one or more required jobs did not succeed"; exit 1'
     - name: Report Successful CI
       run: echo "ci passed"
   release:

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/defaults/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/defaults/expected/ci.yml
@@ -174,7 +174,11 @@ jobs:
     - lint
     - test
     - build
+    if: always()
     steps:
+    - name: Report Failed CI
+      if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+      run: 'echo "ci failed: one or more required jobs did not succeed"; exit 1'
     - name: Report Successful CI
       run: echo "ci passed"
   release:

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/flattenTests/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/flattenTests/expected/ci.yml
@@ -178,7 +178,11 @@ jobs:
     - lint
     - test
     - build
+    if: always()
     steps:
+    - name: Report Failed CI
+      if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+      run: 'echo "ci failed: one or more required jobs did not succeed"; exit 1'
     - name: Report Successful CI
       run: echo "ci passed"
   release:

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/groupTests/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/groupTests/expected/ci.yml
@@ -183,7 +183,11 @@ jobs:
     - lint
     - test
     - build
+    if: always()
     steps:
+    - name: Report Failed CI
+      if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+      run: 'echo "ci failed: one or more required jobs did not succeed"; exit 1'
     - name: Report Successful CI
       run: echo "ci passed"
   release:

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/mappedJobs/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/mappedJobs/expected/ci.yml
@@ -200,7 +200,11 @@ jobs:
     - test
     - compile-examples
     - build
+    if: always()
     steps:
+    - name: Report Failed CI
+      if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+      run: 'echo "ci failed: one or more required jobs did not succeed"; exit 1'
     - name: Report Successful CI
       run: echo "ci passed"
   release:

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/services/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/services/expected/ci.yml
@@ -180,7 +180,11 @@ jobs:
     - lint
     - test
     - build
+    if: always()
     steps:
+    - name: Report Failed CI
+      if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+      run: 'echo "ci failed: one or more required jobs did not succeed"; exit 1'
     - name: Report Successful CI
       run: echo "ci passed"
   release:

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/settingsOverrides/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/settingsOverrides/expected/ci.yml
@@ -177,7 +177,11 @@ jobs:
     - lint
     - test
     - build
+    if: always()
     steps:
+    - name: Report Failed CI
+      if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+      run: 'echo "ci failed: one or more required jobs did not succeed"; exit 1'
     - name: Report Successful CI
       run: echo "ci passed"
   release:

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowEnv/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowEnv/expected/ci.yml
@@ -174,7 +174,11 @@ jobs:
     - lint
     - test
     - build
+    if: always()
     steps:
+    - name: Report Failed CI
+      if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+      run: 'echo "ci failed: one or more required jobs did not succeed"; exit 1'
     - name: Report Successful CI
       run: echo "ci passed"
   release:

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowTriggers/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowTriggers/expected/ci.yml
@@ -173,7 +173,11 @@ jobs:
     - lint
     - test
     - build
+    if: always()
     steps:
+    - name: Report Failed CI
+      if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+      run: 'echo "ci failed: one or more required jobs did not succeed"; exit 1'
     - name: Report Successful CI
       run: echo "ci passed"
   release:


### PR DESCRIPTION
The generated `ci` job is the aggregate check repositories are told to require in branch protection —
including in the documentation added by #719. It declares `needs` on lint, test and build with no
condition, so **GitHub skips it when any of them fails** — and
[a job skipped by a conditional is reported to branch protection as a success](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks).

So the single required check passed *precisely when* the jobs it guards had failed. The gate
protected the branch only while nothing was wrong.

## It has already happened twice

| PR | Failing jobs | `ci` | Result |
| --- | --- | --- | --- |
| #694 | `Lint` | *skipped* | Merged. Left `main`'s generated `ci.yml` out of sync with `V.scala`; needed #724 |
| #726 | `Build`, `Lint`, `Test (17)`, `Test (21)`, `Test (25)` | *skipped* | Merged. Set `sbt.version=2.0.6` with sbt 1 plugins, so **`main` could not load at all**; needed #728 |

Both were auto-approved and auto-merged, because as far as branch protection was concerned
everything required had passed. #726 is the stark case: *every* real check failed and it still
merged.

## The fix

```yaml
ci:
  needs: [lint, test, build]
  if: always()                     # run regardless of what happened upstream
  steps:
    - name: Report Failed CI
      if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
      run: 'echo "ci failed: one or more required jobs did not succeed"; exit 1'
    - name: Report Successful CI
      run: echo "ci passed"
```

A failed lint or test now produces a **failed** `ci`, and the merge is blocked.

Only `failure` and `cancelled` count. A dependency that was *skipped* was skipped by its own
condition, deliberately, and should not fail the gate — that matters for adopters with a conditional
job in `ciPullRequestApprovalJobs`.

## Why every golden moves

All eleven `ci.yml` fixtures contain the `ci` job, so all of them change. That is the point: they now
pin `if: always()` and the failing step, so the behaviour cannot silently regress.

This was chosen over the alternative of listing `Lint`, `Build` and `Test (…)` as required checks in
branch protection. That would restate in repo settings what `needs` already expresses, in a place the
build cannot see — and pinning generated matrix names like `Test (21)` means that changing
`ciTargetJavaVersions` leaves a required check that never reports, blocking every pull request
indefinitely with no obvious cause. The fixture assertion is versioned with the code and cannot
drift.

## Compatibility

**Breaking, deliberately.** Repositories will see `ci` start failing on pull requests whose lint,
test or build jobs fail, where it previously reported success. That is the fix — but a repository
that has been relying on the old behaviour to land bot PRs will notice the change.

Worth calling out in the release notes alongside it: this closes the mechanism by which dependency
bumps have been landing red.

## Verification

All 13 scripted fixtures pass; `sbt lint` and `sbt ciCheckGithubWorkflow` clean; compiles under
`enableStrictCompile`. The repo's own `.github/workflows/ci.yml` is regenerated in this PR, so `main`
gets the fixed gate immediately on merge.