### PR TITLE
Enable the Renovate dashboard, and skip test-fixture workflows

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
-    ":disableDependencyDashboard"
+    "config:recommended"
   ],
   "branchPrefix": "renovate/",
   "customManagers": [
@@ -29,6 +28,16 @@
         ".github/workflows/ci.yml",
         ".github/workflows/auto-approve.yml",
         ".github/workflows/auto-merge.yml"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Workflows under src/sbt-test are scripted-test fixtures, not this repository's CI. They are inputs to the plugin's own tests, so bumping an action in one edits test data rather than a build.",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchFileNames": [
+        "**/src/sbt-test/**"
       ],
       "enabled": false
     },


### PR DESCRIPTION
Two follow-ups to #730, both found while trying to answer a simple question: *how do I see what
Renovate is going to do?*

## Enable the dependency dashboard

#730 disabled it, copying zio/zio's convention. That is fine for a settled Renovate setup, but this
repository now has a **brand-new custom manager reading `V.scala`**. The dashboard is where Renovate
reports what it found, what it is holding back and why — and it carries the checkbox that triggers a
run. That is precisely what is wanted while confirming the manager behaves.

## Skip workflows under `src/sbt-test`

```
zio-sbt-ecosystem/src/sbt-test/zio-sbt-ecosystem/verifySettingsWithCI/.github/workflows/ci.yml
```

The `github-actions` manager picks this up because of its path, but it is a **scripted-test fixture**.
Bumping an action there edits a test's expectations, not a build. Excluded, along with anything else
under `src/sbt-test`.

That accounts for the manager's file count exactly: 6 real workflows + 1 fixture = the 7 it reports.

## What is verified, and what is not

Worth being precise, because I got this wrong twice before getting it right.

**Verified.** A dry run confirms the custom manager works — the `regex` manager reports
`fileCount: 1, depCount: 7`, which is `V.scala` and its seven versioned pins. The `depCount` is the
part that matters: matching the file but extracting nothing would be the silent failure.

**Not verifiable with these tools.** The exclusions:

- `packageRules` with `enabled: false` act when **looking up** updates, not when extracting, so the
  file still appears in extraction counts either way. `fileCount` can never confirm them.
- A dry run against a remote repo reads the **committed** config from the default branch, so it
  cannot test an uncommitted edit at all — every dry run I did before realising this was validating
  #730's merged file.
- Passing the file via `RENOVATE_CONFIG_FILE` does not help: global config **merges with** repo
  config rather than replacing it. The custom manager then runs twice and reports
  `fileCount: 2, depCount: 14`.

The dashboard is how these get confirmed — which is the other reason to turn it on.

Also worth recording from #730: `renovate-config-validator` does **not** check `versioningTemplate`.
A deliberately bogus scheme name validates just as cleanly, so a passing validator is no evidence a
value is real.

## Not included

`README.md` and `docs/index.md` contain sample action pins, and I initially thought Renovate was
managing them. It is not — the `github-actions` manager only matches workflow paths, and the file
count arithmetic above confirms it. No exclusion needed.