### PR TITLE
Hold sbt on 1.x in Renovate until the sbt 2 migration lands

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -42,6 +42,13 @@
       "enabled": false
     },
     {
+      "description": "Hold sbt on 1.x. Moving to sbt 2 needs the plugins in project/plugins.sbt migrated as well - see #684, #689 and #699 - so a bare version bump does not work. #726 did exactly that and left main unable to load at all, because the plugins have no sbt 2 builds; it was reverted in #728. Remove this once the migration lands.",
+      "matchPackageNames": [
+        "sbt/sbt"
+      ],
+      "allowedVersions": "<2"
+    },
+    {
       "description": "A pin bumped in V.scala leaves the committed workflows stale until `sbt ciGenerateGithubWorkflow` is run, so these need a follow-up commit before they can merge.",
       "matchManagers": [
         "custom.regex"


### PR DESCRIPTION
A Renovate dry run shows it would open a PR for **sbt 2.x** against `project/build.properties`.

That upgrade cannot work as a version bump: the plugins in `project/plugins.sbt` have no sbt 2
builds, so resolution fails before the build even loads.

```
Error downloading org.portable-scala:sbt-scalajs-crossproject_sbt2_3:1.3.2
  not found: https://repo1.maven.org/maven2/org/portable-scala/sbt-scalajs-crossproject_sbt2_3/...
```

**#726 made exactly that change** — one line, `sbt.version` 1.12.15 → 2.0.6 — and left `main` unable
to load anything at all. It was reverted in #728. Migrating properly means moving the plugins over
too, which is what #684, #689 and #699 are for.

## Why a constraint rather than just closing the PR

Renovate will re-propose it after every revert, indefinitely. And it looks like an ordinary
dependency bump to whoever sees it next — which is how it merged the first time.

Since #729 the `ci` gate would block it from merging red, so the damage is capped at noise. But that
mitigates the symptom; this removes the trap.

```json
{
  "matchPackageNames": ["sbt/sbt"],
  "allowedVersions": "<2"
}
```

`sbt/sbt` is the dependency name Renovate uses for the sbt version itself — confirmed from a
`--dry-run=extract` against `project/build.properties`, and distinct from `sbt/setup-sbt`, which is
the action and stays unconstrained.

**Remove this rule once the migration lands.** The description says so inline, so it does not become
a mystery constraint.

Validator passes.