### PR TITLE
Hold sbt on 1.x in Scala Steward

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,17 @@
+# Scala Steward configuration.
+#
+# See https://github.com/scala-steward-org/scala-steward/blob/main/docs/repo-specific-configuration.md
+
+# Hold sbt on the 1.x series.
+#
+# Moving to sbt 2 is not a version bump: the plugins in project/plugins.sbt have no sbt 2 builds, so
+# resolution fails before the build even loads. #726 changed only sbt.version, from 1.12.15 to 2.0.6,
+# and left main unable to load anything; it was reverted in #728. Migrating properly means moving the
+# plugins over too, which is what #684, #689 and #699 are for.
+#
+# This is a pin rather than an ignore so that 1.x updates still arrive.
+#
+# Remove once the sbt 2 migration lands.
+updates.pin = [
+  { groupId = "org.scala-sbt", artifactId = "sbt", version = "1." }
+]


### PR DESCRIPTION
Adds a `.scala-steward.conf`, which this repository did not have.

## Why #733 was not enough

**#726 — the sbt 2.0.6 bump that left `main` unable to load — was opened by `zio-scala-steward`, not
Renovate.**

#733 added `matchPackageNames: ["sbt/sbt"], allowedVersions: "<2"` to `renovate.json`. That holds the
wrong bot. And it would not have mattered either way: **Renovate has not run on this repository since
September 2025** (last PR #544), though it is active elsewhere in the org — `zio/zio` had a Renovate
PR today.

Scala Steward *is* running here — #717, #726 and #727 are all its work, and it runs nightly on a cron.
With no `.scala-steward.conf`, nothing prevented it re-proposing sbt 2 after the revert.

## The config

```hocon
updates.pin = [
  { groupId = "org.scala-sbt", artifactId = "sbt", version = "1." }
]
```

- `org.scala-sbt:sbt` is the coordinate **Scala Steward itself reports** for the sbt version in
  `project/build.properties` — taken from #726's own PR body, which prints the config snippet to use.
- `version` is a **prefix**, so 1.x updates still arrive. That is why this is a pin rather than an
  `updates.ignore`, which would stop them entirely.

## Context

Moving to sbt 2 is not a version bump: the plugins in `project/plugins.sbt` have no sbt 2 builds, so
resolution fails before the build loads at all. #684, #689 and #699 are the actual migration.
**Remove this pin once one of them lands.** The comment in the file says so, so it does not become a
mystery constraint.

Since #729 the `ci` gate would block such a bump from merging red — which is a real safety net, and
is what would have prevented #726 landing. But it catches the symptom after the fact; this stops the
proposal.

## Also worth knowing

Because Renovate is not running here, **`.github/dependabot.yml` must stay.** #730 anticipated
removing it once Renovate had demonstrably opened a `V.scala` PR; that has not happened and will not
until the app is enabled on this repository. The `renovate.json` config itself is correct — a dry run
confirms the custom manager extracts all seven pins from `V.scala` — it simply has nothing executing
it.