### PR TITLE
fix(ci): stop the build job from swallowing its own failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    continue-on-error: true
+    continue-on-error: false
     steps:
     - name: Git Checkout
       uses: actions/checkout@v7.0.1

--- a/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
+++ b/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
@@ -144,7 +144,16 @@ object ZioSbtCiPlugin extends AutoPlugin {
       Job(
         id = "build",
         name = "Build",
-        continueOnError = true,
+        // Must stay false.
+        //
+        // With continue-on-error the job reports success to `needs` even when a step failed, so
+        // `needs.*.result` never reads 'failure' and the `ci` gate below cannot see the breakage.
+        // The build job then fails silently for as long as nobody reads the logs: zio-sbt's own
+        // "Check website build process" step was red from 2026-08-11 to 2026-08-20 under a green
+        // CI badge, because Dependabot had bumped Docusaurus without its peers.
+        //
+        // A repository that genuinely needs a non-blocking build job can override `ciBuildJobs`.
+        continueOnError = false,
         steps = {
           (if (swapSizeGB > 0) Seq(setSwapSpace) else Seq.empty) ++
             Seq(

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/bothPlugins/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/bothPlugins/expected/ci.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    continue-on-error: true
+    continue-on-error: false
     steps:
     - name: Git Checkout
       uses: actions/checkout@v7.0.1

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/concurrency/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/concurrency/expected/ci.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    continue-on-error: true
+    continue-on-error: false
     steps:
     - name: Git Checkout
       uses: actions/checkout@v7.0.1

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/defaults/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/defaults/expected/ci.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    continue-on-error: true
+    continue-on-error: false
     steps:
     - name: Git Checkout
       uses: actions/checkout@v7.0.1

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/flattenTests/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/flattenTests/expected/ci.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    continue-on-error: true
+    continue-on-error: false
     steps:
     - name: Git Checkout
       uses: actions/checkout@v7.0.1

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/groupTests/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/groupTests/expected/ci.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    continue-on-error: true
+    continue-on-error: false
     steps:
     - name: Git Checkout
       uses: actions/checkout@v7.0.1

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/mappedJobs/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/mappedJobs/expected/ci.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-22.04
-    continue-on-error: true
+    continue-on-error: false
     steps:
     - name: Git Checkout
       uses: actions/checkout@v7.0.1

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/services/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/services/expected/ci.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    continue-on-error: true
+    continue-on-error: false
     steps:
     - name: Git Checkout
       uses: actions/checkout@v7.0.1

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/settingsOverrides/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/settingsOverrides/expected/ci.yml
@@ -27,7 +27,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    continue-on-error: true
+    continue-on-error: false
     steps:
     - name: Git Checkout
       uses: actions/checkout@v7.0.1

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowEnv/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowEnv/expected/ci.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    continue-on-error: true
+    continue-on-error: false
     steps:
     - name: Git Checkout
       uses: actions/checkout@v7.0.1

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowTriggers/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowTriggers/expected/ci.yml
@@ -22,7 +22,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    continue-on-error: true
+    continue-on-error: false
     steps:
     - name: Git Checkout
       uses: actions/checkout@v7.0.1


### PR DESCRIPTION
Follow-up to #741, which documented this but deliberately left it out of scope.

## The problem

The generated build job carries `continue-on-error: true`. GitHub then records the **job** as successful even when a step failed, so the value the `ci` gate reads is always `success`:

```yaml
  ci:
    needs: [lint, test, build]
    if: always()
    steps:
    - name: Report Failed CI
      if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
      run: 'echo "ci failed: one or more required jobs did not succeed"; exit 1'
```

The gate itself is correct — it was hardened in this same file after #694 merged over a red Lint job. But `continue-on-error` made the build job structurally invisible to it. A failing build could not turn the run red, and nothing short of reading the logs would reveal it.

**This already happened.** zio-sbt's own `Check website build process` step failed continuously from 2026-08-11 to 2026-08-20 while every run reported success. Run [32053458722](https://github.com/zio/zio-sbt/actions/runs/32053458722):

```json
{"conclusion":"failure","name":"Build","steps":[
  ..., {"conclusion":"failure","name":"Check website build process"}, ...]}
```

Green badge, failing job. The website build was broken that whole time because Dependabot had bumped Docusaurus without its peers — fixed in #741, but nine days after it broke.

## The change

`continueOnError = false` on the build job in `ZioSbtCiPlugin.scala`, plus regenerated workflows.

A repository that genuinely wants a non-blocking build job can still override `ciBuildJobs`, which is noted in a comment at the call site so this does not get reintroduced.

## Verification

`sbt zio-sbt-ci/scripted` — all 13 pass (244s):

```
+ zio-sbt-ci/bothPlugins      + zio-sbt-ci/mappedJobs
+ zio-sbt-ci/concurrency      + zio-sbt-ci/services
+ zio-sbt-ci/customJobs       + zio-sbt-ci/settingsOverrides
+ zio-sbt-ci/defaults         + zio-sbt-ci/workflowEnv
+ zio-sbt-ci/driftCheck       + zio-sbt-ci/workflowTitle
+ zio-sbt-ci/flattenTests     + zio-sbt-ci/workflowTriggers
+ zio-sbt-ci/groupTests
```

`driftCheck` is the useful one: it builds its baseline at runtime rather than from a checked-in fixture, so it confirms the generator and the committed `.github/workflows/ci.yml` agree. Re-running `ciGenerateGithubWorkflow` on this branch produces no diff.

## Note for downstream

Any ZIO repository that regenerates its workflow gets a **blocking** build job. Repos whose build has been quietly failing will go red on the next run. That is the intent, but it is a real behavior change worth calling out in release notes.