### PR TITLE
fix(website): only sideline a prerelease when a stable release exists

### DIFF
--- a/zio-sbt-website/src/main/scala/zio/sbt/WebsitePlugin.scala
+++ b/zio-sbt-website/src/main/scala/zio/sbt/WebsitePlugin.scala
@@ -334,7 +334,26 @@ object WebsitePlugin extends sbt.AutoPlugin {
         case _                      => None
       }
     }
-    val npmTag = prereleaseTag.map(tag => s"--tag $tag").getOrElse("")
+
+    // Sideline a prerelease under its own dist-tag only when a stable release
+    // already holds `latest`. For a project that has never released a stable
+    // version the prerelease *is* the current release, and parking it under
+    // `rc` freezes `latest` on an older version - which hides the docs from
+    // dependency bots, since Renovate's respectLatest will not go past `latest`.
+    val packageName: String =
+      """"name"\s*:\s*"([^"]+)"""".r
+        .findFirstMatchIn(IO.read(new File(docsDir, "package.json")))
+        .map(_.group(1))
+        .getOrElse(sys.error(s"Could not read the package name from ${docsDir / "package.json"}"))
+
+    val currentLatest: Option[String] = {
+      val out  = new mutable.StringBuilder
+      val code = Process(s"npm view $packageName dist-tags.latest", docsDir)
+        .!(ProcessLogger(line => { out.append(line); () }, _ => ()))
+      Some(out.toString.trim).filter(_.nonEmpty && code == 0)
+    }
+    val latestIsStable = currentLatest.exists(!_.contains("-"))
+    val npmTag         = prereleaseTag.filter(_ => latestIsStable).map(tag => s"--tag $tag").getOrElse("")
 
     exit(Process(s"npm version $version --no-git-tag-version", docsDir).!)
     exit(Process(s"npm pkg set repository.url=$repoUrl", docsDir).!)


### PR DESCRIPTION
## Problem

`publishToNpm` derives the npm dist-tag from the prerelease identifier in the version, so `1.0.0-RC27` publishes as `--tag rc` and `latest` stays where it was.

That is the right call when a project has a stable release and is previewing the next line. `@zio.dev/zio-telemetry` is at `3.1.19` with `4.0.0-RC12` in flight, and zio.dev should keep documenting 3.1.19 — otherwise readers follow docs for an API they cannot depend on yet.

It is the wrong call when the project has never released a stable version. Every `zio-dynamodb` release is `1.0.0-RCxx`. There is nothing more current for `latest` to point at, so sidelining each release under `rc` doesn't defer the docs — it freezes them:

```
@zio.dev/zio-dynamodb
  latest : 1.0.0-RC24     (2025-12-08)
  rc     : 1.0.0-RC27     (2026-08-20)
```

Dependency bots read `latest`. Renovate's `respectLatest` is enabled by default for npm and will not propose a version above that tag, so zio.dev silently stopped following the project after RC24. RC25, RC26 and RC27 all shipped without the docs moving.

This is a regression rather than a policy the ecosystem settled on. The derivation landed in #592 on **2025-12-15**; zio-dynamodb's last docs publish was **2025-12-08**, seven days earlier. Its `latest` is a prerelease precisely because it predates the change, and each RC-only project gets frozen as it cuts its next release. Four others are in the same position today, with prereleases currently on `latest`:

| package | `latest` |
| --- | --- |
| `@zio.dev/zio-prelude` | 1.0.0-RC44 |
| `@zio.dev/zio-direct` | 1.0.0-RC7 |
| `@zio.dev/zio-amqp` | 1.0.0-alpha.3 |
| `@zio.dev/zio-meta` | 0.0.0--21-54bc2e8b-SNAPSHOT |

## Change

The deciding factor is not whether the incoming version is a prerelease, but whether a **stable release already holds `latest`**. Query the registry and sideline the prerelease only in that case:

```scala
val currentLatest: Option[String] = { /* npm view <pkg> dist-tags.latest */ }
val latestIsStable = currentLatest.exists(!_.contains("-"))
val npmTag = prereleaseTag.filter(_ => latestIsStable).map(tag => s"--tag $tag").getOrElse("")
```

A package whose `latest` is itself a prerelease, or that has no published version at all, publishes to `latest`. The prerelease-tag derivation from #592 is kept as-is and simply gated.

The `hash` and `snapshot` publishing paths are untouched — those are deliberately separate streams.

## Behaviour

| project | before | after |
| --- | --- | --- |
| zio-telemetry (`3.1.19` stable, publishing `4.0.0-RC12`) | `--tag rc` | `--tag rc` — unchanged, docs stay on 3.1.19 |
| zio-dynamodb (`latest` is `1.0.0-RC24`, publishing `RC27`) | `--tag rc`, docs frozen | publishes to `latest`, docs follow the project |
| any project publishing a stable release | `latest` | `latest` — unchanged |
| first ever publish of a package | `latest` (or `--tag` if prerelease) | `latest` |

Once a project cuts its first stable release, it automatically gets the zio-telemetry behaviour from then on — no per-project configuration anywhere.

## Verification

`sbt clean scalafmtCheckAll compile` passes.

The condition was exercised against the live registry:

```
@zio.dev/zio-dynamodb   latest=1.0.0-RC24  prerelease -> publish to latest
@zio.dev/zio-telemetry  latest=3.1.19      stable     -> publish under --tag
@zio.dev/zio-prelude    latest=1.0.0-RC44  prerelease -> publish to latest
(unpublished package)   no latest                     -> publish to latest
```

## Context

zio/zio#11151 tried to solve this on the consumer side by setting `respectLatest: false` for `@zio.dev/**`. Without the dist-tag ceiling Renovate falls back to semver ordering, and these RC identifiers are not zero-padded — semver compares alphanumeric prerelease identifiers as strings, so `1.0.0-RC9` outranks `1.0.0-RC27`. Renovate opened a PR downgrading zio-dynamodb from RC24 to RC9. That change is being reverted in zio/zio#11156, which leaves this as the fix.

Packages already sidelined under `rc` will correct themselves at their next docs release. To fix one sooner takes a one-off registry operation by someone with publish rights, e.g. `npm dist-tag add @zio.dev/zio-dynamodb@1.0.0-RC27 latest`.
