### PR TITLE
chore(ci): remove the unused CheckReadme step

### DIFF
--- a/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
+++ b/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
@@ -1017,15 +1017,4 @@ object ZioSbtCiPlugin extends AutoPlugin {
     )
   }
 
-  val CheckReadme: Def.Initialize[SingleStep] = Def.setting {
-    val backgroundJobs = ciBackgroundJobs.value
-
-    val prefixJobs = makePrefixJobs(backgroundJobs)
-
-    Step.SingleStep(
-      name = "Check if the README file is up to date",
-      run = Some(prefixJobs + "sbt docs/checkReadme")
-    )
-  }
-
 }


### PR DESCRIPTION
`ZioSbtCiPlugin.CheckReadme` is defined and referenced nowhere.

It is a leftover from the 2023 job layout, when the build job ran:

```yaml
    - name: Check if the README file is up to date
      run: sbt docs/checkReadme
```

That step left the build job long ago — README generation now lives in the update-readme job, which uses `GenerateReadme` — but the step definition stayed behind. A search across the plugin sources, the scripted fixtures, the generated workflows, and the docs turns up exactly one hit, the definition itself:

```
zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala:1020:  val CheckReadme: Def.Initialize[SingleStep] = Def.setting {
```

The `docs/checkReadme` **task** is untouched — it is still defined and wired up in `WebsitePlugin` (`checkReadme := checkReadmeTask.value`). This removes only the unused CI *step* wrapper.

Found while investigating the history of the build job's `continue-on-error` flag in #743.

## Note

`CheckReadme` is a public `val` on the plugin object, so this is technically source-visible. The repo has no MiMa configuration and the value is unreferenced, but flagging it in case any downstream build constructs custom jobs from these step definitions.

## Verification

`sbt zio-sbt-ci/compile` — success. No generated workflow changes (the step produced no YAML, since nothing used it).