### PR TITLE
Move onBrokenMarkdownLinks under markdown.hooks

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -12,7 +12,11 @@ const config = {
   url: 'http://localhost:3000',
   baseUrl: '/',
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'throw',
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: 'throw',
+    },
+  },
   favicon: 'img/favicon.png',
 
   organizationName: 'zio', 


### PR DESCRIPTION
Same change as zio/zio-http#4266, applied here.

The top-level `onBrokenMarkdownLinks` option is deprecated and will be removed in Docusaurus v4. This repository is on Docusaurus 3.10.2, so every website build logs the migration notice four times:

```
[WARNING] The `siteConfig.onBrokenMarkdownLinks` config option is deprecated and will be removed in Docusaurus v4.
Please migrate and move this option to `siteConfig.markdown.hooks.onBrokenMarkdownLinks` instead.
```

Moved to the location Docusaurus asks for, preserving the `throw` severity:

```js
markdown: {
  hooks: {
    onBrokenMarkdownLinks: 'throw',
  },
},
```

The change is behaviour-neutral for v3. Docusaurus already copies the deprecated option into `markdown.hooks.onBrokenMarkdownLinks` and erases the old key during config validation, so only the location changes.

### Verification

`yarn build` in `website/`, before and after:

| | Deprecation warnings | Broken links | Exit |
| --- | --- | --- | --- |
| before | 4 | 0 | 0 |
| after | 0 | 0 | 0 |
