### PR TITLE
fix(website): apply the webpack pin only when the scaffold needs it

### DIFF
--- a/zio-sbt-website/src/main/scala/zio/sbt/WebsitePlugin.scala
+++ b/zio-sbt-website/src/main/scala/zio/sbt/WebsitePlugin.scala
@@ -248,18 +248,30 @@ object WebsitePlugin extends sbt.AutoPlugin {
 
         exit(s"rm -rvf ${websiteDirPath.toString}/.git/".!)
 
-        // Docusaurus 2.1.0 uses ProgressPlugin options removed in webpack >=5.76.
-        // Pin webpack to 5.75.0 via npm overrides and reinstall until Docusaurus is upgraded.
+        // Docusaurus 2.x uses ProgressPlugin options that webpack >=5.76 removed, so a site
+        // scaffolded on 2.x must pin webpack to 5.75.0 or `npm run build` breaks.
+        //
+        // The pin is applied only when the scaffold really is on 2.x. Docusaurus 3.x depends on
+        // webpack ^5.95.0, where pinning 5.75.0 is unsatisfiable and fails `npm install` with
+        // ERESOLVE. Keying the override off the scaffolded version lets the pin retire itself
+        // when create-zio-website moves to Docusaurus 3, instead of turning into a broken
+        // constraint for every project that scaffolds a new site.
         val pkgJsonFile    = new File(s"${websiteDirPath}/package.json")
         val pkgJsonContent = IO.read(pkgJsonFile)
-        val patched        = pkgJsonContent.fromJson[Json.Obj] match {
-          case Right(obj) =>
-            Json
-              .Obj(obj.fields :+ ("overrides" -> Json.Obj(Chunk("webpack" -> Json.Str("5.75.0")))))
-              .toJsonPretty + "\n"
-          case Left(err) => sys.error(s"Failed to parse package.json: $err")
+        val pkgJson        = pkgJsonContent.fromJson[Json.Obj] match {
+          case Right(obj) => obj
+          case Left(err)  => sys.error(s"Failed to parse package.json: $err")
         }
-        IO.write(pkgJsonFile, patched)
+
+        if (docusaurusMajorOf(pkgJson).exists(_ < 3)) {
+          logger.info("Docusaurus 2.x scaffold detected, pinning webpack to 5.75.0.")
+          val patched =
+            Json
+              .Obj(pkgJson.fields :+ ("overrides" -> Json.Obj(Chunk("webpack" -> Json.Str("5.75.0")))))
+              .toJsonPretty + "\n"
+          IO.write(pkgJsonFile, patched)
+        }
+
         exit(Process("npm install", new File(s"${websiteDirPath}")).!)
       }
 
@@ -385,6 +397,24 @@ object WebsitePlugin extends sbt.AutoPlugin {
     exit(Process(s"npm pkg set repository.url=$repoUrl", docsDir).!)
     exit("npm config set access public".!)
     exit(Process(s"npm publish $npmTag".trim, docsDir).!)
+  }
+
+  /**
+   * Major version of `@docusaurus/core` declared in a scaffolded site's
+   * package.json, if it can be determined. Returns None when the dependency is
+   * absent or the version is not a plain number, in which case callers should
+   * not assume anything about the Docusaurus generation in use.
+   */
+  private[sbt] def docusaurusMajorOf(pkgJson: Json.Obj): Option[Int] = {
+    def field(obj: Json.Obj, key: String): Option[Json] =
+      obj.fields.collectFirst { case (k, v) if k == key => v }
+
+    for {
+      deps    <- field(pkgJson, "dependencies").collect { case o: Json.Obj => o }
+      version <- field(deps, "@docusaurus/core").collect { case Json.Str(v) => v }
+      digits   = version.dropWhile(!_.isDigit).takeWhile(_.isDigit)
+      major   <- scala.util.Try(digits.toInt).toOption
+    } yield major
   }
 
   private def hashVersion: Option[String] =

--- a/zio-sbt-website/src/sbt-test/zio-sbt-website/installWebsite/build.sbt
+++ b/zio-sbt-website/src/sbt-test/zio-sbt-website/installWebsite/build.sbt
@@ -1,8 +1,45 @@
+import zio.json._
+import zio.json.ast.Json
+
 lazy val root = (project in file("."))
   .settings(
     version        := "0.1",
     projectName    := "ZIO SBT",
     mainModuleName := "test-project",
-    projectStage   := ProjectStage.ProductionReady
+    projectStage   := ProjectStage.ProductionReady,
+
+    // create-zio-website still scaffolds Docusaurus 2.1.0, which needs webpack pinned to 5.75.0.
+    // The pin is conditional on the scaffolded major version, so assert it is actually applied
+    // here; if the scaffold ever moves to Docusaurus 3, this expectation flips to `absent`.
+    TaskKey[Unit]("checkWebpackPin") := {
+      val pkgJson = IO.read(baseDirectory.value / "website" / "package.json")
+      val obj     = pkgJson.fromJson[Json.Obj].fold(err => sys.error(s"bad package.json: $err"), identity)
+
+      def field(o: Json.Obj, k: String): Option[Json] =
+        o.fields.collectFirst { case (n, v) if n == k => v }
+
+      val docusaurus = field(obj, "dependencies")
+        .collect { case o: Json.Obj => o }
+        .flatMap(field(_, "@docusaurus/core"))
+        .collect { case Json.Str(v) => v }
+        .getOrElse(sys.error("scaffold has no @docusaurus/core dependency"))
+
+      val pinned = field(obj, "overrides")
+        .collect { case o: Json.Obj => o }
+        .flatMap(field(_, "webpack"))
+        .collect { case Json.Str(v) => v }
+
+      if (docusaurus.startsWith("2.")) {
+        assert(
+          pinned.contains("5.75.0"),
+          s"Docusaurus $docusaurus scaffold must pin webpack to 5.75.0, found: $pinned"
+        )
+      } else {
+        assert(
+          pinned.isEmpty,
+          s"Docusaurus $docusaurus must not carry the webpack 5.75.0 pin, found: $pinned"
+        )
+      }
+    }
   )
   .enablePlugins(WebsitePlugin)

--- a/zio-sbt-website/src/sbt-test/zio-sbt-website/installWebsite/test
+++ b/zio-sbt-website/src/sbt-test/zio-sbt-website/installWebsite/test
@@ -4,6 +4,10 @@ $ exists website/src
 $ exists website/static
 $ exists website/LICENSE
 
+# The webpack 5.75.0 override is applied only to a Docusaurus 2.x scaffold, so that the pin
+# retires itself rather than becoming an unsatisfiable constraint on Docusaurus 3.
+> checkWebpackPin
+
 # Running installWebsite again should succeed and be a no-op: since the website
 # directory already exists, the task warns and skips scaffolding instead of
 # removing/reinstalling it.


### PR DESCRIPTION
Follow-up to #741. That PR fixed this repository's own site; this one stops the same failure reaching downstream projects.

## The problem

`installWebsite` unconditionally injects a webpack override into every freshly scaffolded site:

```scala
Json.Obj(obj.fields :+ ("overrides" -> Json.Obj(Chunk("webpack" -> Json.Str("5.75.0")))))
```

The pin is **correct today**. `create-zio-website@0.0.1-alpha.14` — the version the plugin pins, and the newest published, from 2023-07-15 — scaffolds Docusaurus 2.1.0, which uses ProgressPlugin options that webpack ≥5.76 removed. I confirmed this by unpacking the tarball:

```json
"@docusaurus/core": "2.1.0",
"@mdx-js/react": "^1.6.22",
"react": "^17.0.2"
```

It stops being correct the moment that scaffold moves to Docusaurus 3, which depends on webpack `^5.95.0`. Pinning 5.75.0 then becomes unsatisfiable and `npm install` fails outright with `ERESOLVE` — the exact failure #741 spent a PR untangling, except here it would hit every project that scaffolds a new site rather than one repository.

## The change

Derive the decision from the scaffold rather than hardcoding it — read `@docusaurus/core` from the generated `package.json` and apply the override only when its major is below 3:

```scala
if (docusaurusMajorOf(pkgJson).exists(_ < 3)) {
  logger.info("Docusaurus 2.x scaffold detected, pinning webpack to 5.75.0.")
  ...
}
```

The pin now retires itself when `create-zio-website` is upgraded, instead of becoming a broken constraint someone has to diagnose from an ERESOLVE dump.

**Behavior today is unchanged** — the scaffold is 2.1.0, so the pin is still applied.

## Edge cases

`docusaurusMajorOf` tolerates range prefixes and prereleases; an absent or unparseable version yields no pin:

| Declared version | Major | Pin applied |
|---|---|---|
| `2.1.0`, `~2.4.1`, `2.1.0-beta.3` | 2 | yes |
| `3.10.2`, `^3.0.0`, `>=3.1.0` | 3 | no |
| `latest`, `workspace:*`, absent | — | no |

Defaulting to no-pin errs toward a clear webpack error at build time over an ERESOLVE failure at install time.

## Verification

The `installWebsite` scripted test now asserts the resulting state, keyed off the scaffolded major so it stays honest when the scaffold moves — it flips to requiring the pin's *absence* on Docusaurus 3 rather than needing to be rewritten:

```
$ sbt "zio-sbt-website/scripted zio-sbt-website/installWebsite"
+ zio-sbt-website/installWebsite
[success] Total time: 196 s
```

That test performs a real `npx create-zio-website` scaffold and `npm install`, so it exercises the actual path rather than a fixture.