### PR TITLE
fix(ci): run sbt without colours in generated workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,11 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Check all code compiles
-      run: sbt +Test/compile
+      run: sbt --no-colors +Test/compile
     - name: Check artifacts build process
-      run: sbt +publishLocal
+      run: sbt --no-colors +publishLocal
     - name: Check website build process
-      run: sbt docs/clean; sbt docs/buildWebsite
+      run: sbt --no-colors docs/clean; sbt --no-colors docs/buildWebsite
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -71,9 +71,9 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Check if the site workflow is up to date
-      run: sbt ciCheckGithubWorkflow
+      run: sbt --no-colors ciCheckGithubWorkflow
     - name: Lint
-      run: sbt lint
+      run: sbt --no-colors lint
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -103,7 +103,7 @@ jobs:
       with:
         fetch-depth: '0'
     - name: Test
-      run: sbt +test
+      run: sbt --no-colors +test
   update-readme:
     name: Update README
     runs-on: ubuntu-latest
@@ -127,7 +127,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Generate Readme
-      run: sbt docs/generateReadme
+      run: sbt --no-colors docs/generateReadme
     - name: Commit Changes
       run: |
         git config --local user.email "zio-assistant[bot]@users.noreply.github.com"
@@ -208,7 +208,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Release
-      run: sbt ci-release
+      run: sbt --no-colors ci-release
       env:
         PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
         PGP_SECRET: ${{ secrets.PGP_SECRET }}
@@ -244,7 +244,7 @@ jobs:
         node-version: 24.12.0
         registry-url: https://registry.npmjs.org
     - name: Publish Docs to NPM Registry
-      run: sbt docs/publishToNpm
+      run: sbt --no-colors docs/publishToNpm
   notify-docs-release:
     name: Notify Docs Release
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -514,7 +514,7 @@ test:
     with:
       fetch-depth: '0'
   - name: Test
-    run: sbt +test
+    run: sbt --no-colors +test
 ```
 
 The `sbt +test` command will run the `test` task for all submodules in the project against all Scala versions defined in the `crossScalaVersions` setting.
@@ -583,7 +583,7 @@ test:
     with:
       fetch-depth: '0'
   - name: Test
-    run: sbt ${{ matrix.scala-project }}/test
+    run: sbt --no-colors ${{ matrix.scala-project }}/test
 ```
 
 ## Documentation

--- a/docs/index.md
+++ b/docs/index.md
@@ -513,7 +513,7 @@ test:
     with:
       fetch-depth: '0'
   - name: Test
-    run: sbt +test
+    run: sbt --no-colors +test
 ```
 
 The `sbt +test` command will run the `test` task for all submodules in the project against all Scala versions defined in the `crossScalaVersions` setting.
@@ -582,5 +582,5 @@ test:
     with:
       fetch-depth: '0'
   - name: Test
-    run: sbt ${{ matrix.scala-project }}/test
+    run: sbt --no-colors ${{ matrix.scala-project }}/test
 ```

--- a/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
+++ b/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
@@ -30,6 +30,17 @@ object ZioSbtCiPlugin extends AutoPlugin {
   override def requires = plugins.CorePlugin
   override def trigger  = allRequirements
 
+  /**
+   * How every generated step invokes sbt.
+   *
+   * `--no-colors` matters more in CI than it looks: with colour on, sbt wraps
+   * its `[error]` and `[warn]` prefixes in ANSI escapes, so a run log cannot be
+   * searched for them. `gh run view --log-failed | grep '[error]'` comes back
+   * empty on a job that failed with sbt errors, and GitHub's own log search has
+   * the same blind spot.
+   */
+  private val SbtCommand = "sbt --no-colors"
+
   object autoImport {
     val ciDocsVersioningScheme: SettingKey[DocsVersioning] = settingKey[DocsVersioning]("Docs versioning style")
     val ciEnabledBranches: SettingKey[Seq[String]]         = settingKey[Seq[String]]("Publish branch for documentation")
@@ -224,7 +235,7 @@ object ZioSbtCiPlugin extends AutoPlugin {
                       name = "Test",
                       condition = Some(Condition.Expression(s"matrix.scala == '$scalaVersion'")),
                       run = Some(
-                        prefixJobs + "sbt ++${{ matrix.scala }}" + makeTests(
+                        prefixJobs + SbtCommand + " ++${{ matrix.scala }}" + makeTests(
                           scalaVersion
                         )
                       )
@@ -251,7 +262,7 @@ object ZioSbtCiPlugin extends AutoPlugin {
                             )
                           ),
                           run = Some(
-                            prefixJobs + "sbt ++${{ matrix.scala }}" ++ s" ${projects.map(_ + "/test ").mkString(" ")}"
+                            prefixJobs + SbtCommand + " ++${{ matrix.scala }}" ++ s" ${projects.map(_ + "/test ").mkString(" ")}"
                           )
                         )
                       )
@@ -302,7 +313,7 @@ object ZioSbtCiPlugin extends AutoPlugin {
             if (javaPlatformMatrix.values.toSet.isEmpty) {
               Step.SingleStep(
                 name = "Test",
-                run = Some(prefixJobs + "sbt ${{ matrix.scala-project }}/test")
+                run = Some(prefixJobs + SbtCommand + " ${{ matrix.scala-project }}/test")
               )
             } else {
               Step.StepSequence(
@@ -311,7 +322,7 @@ object ZioSbtCiPlugin extends AutoPlugin {
                     name = s"Java $javaPlatform Tests",
                     condition = Some(Condition.Expression(s"matrix.java == '$javaPlatform'")),
                     run = Some(
-                      prefixJobs + s"sbt $${{ matrix.scala-project-java$javaPlatform }}/test"
+                      prefixJobs + SbtCommand + s" $${{ matrix.scala-project-java$javaPlatform }}/test"
                     )
                   )
                 }
@@ -341,7 +352,7 @@ object ZioSbtCiPlugin extends AutoPlugin {
             checkout,
             Step.SingleStep(
               name = "Test",
-              run = Some(prefixJobs + "sbt +test")
+              run = Some(prefixJobs + SbtCommand + " +test")
             )
           )
       )
@@ -804,21 +815,21 @@ object ZioSbtCiPlugin extends AutoPlugin {
         Seq(
           Step.SingleStep(
             name = "Check artifacts build process",
-            run = Some("sbt +publishLocal")
+            run = Some(SbtCommand + " +publishLocal")
           )
         ),
       ciCheckWebsiteBuildProcess       := CheckWebsiteBuildProcess.value,
       ciCheckArtifactsCompilationSteps := Seq(
         Step.SingleStep(
           name = "Check all code compiles",
-          run = Some(makePrefixJobs(ciBackgroundJobs.value) + "sbt +Test/compile")
+          run = Some(makePrefixJobs(ciBackgroundJobs.value) + SbtCommand + " +Test/compile")
         )
       ),
       ciCheckGithubWorkflowSteps := Seq(
         Step.SingleStep(
           name = "Check if the site workflow is up to date",
           run = Some(
-            makePrefixJobs(ciBackgroundJobs.value) + "sbt ciCheckGithubWorkflow"
+            makePrefixJobs(ciBackgroundJobs.value) + SbtCommand + " ciCheckGithubWorkflow"
           )
         )
       ),
@@ -953,7 +964,7 @@ object ZioSbtCiPlugin extends AutoPlugin {
       Seq(
         Step.SingleStep(
           name = "Check website build process",
-          run = Some(prefixJobs + "sbt docs/clean; sbt docs/buildWebsite")
+          run = Some(prefixJobs + SbtCommand + " docs/clean; " + SbtCommand + " docs/buildWebsite")
         )
       )
     }
@@ -964,7 +975,7 @@ object ZioSbtCiPlugin extends AutoPlugin {
 
     Step.SingleStep(
       name = "Lint",
-      run = Some(prefixJobs + "sbt lint")
+      run = Some(prefixJobs + SbtCommand + " lint")
     )
   }
 
@@ -975,7 +986,7 @@ object ZioSbtCiPlugin extends AutoPlugin {
 
     Step.SingleStep(
       name = "Release",
-      run = Some(prefixJobs + "sbt ci-release"),
+      run = Some(prefixJobs + SbtCommand + " ci-release"),
       env = Map(
         "PGP_PASSPHRASE"    -> "${{ secrets.PGP_PASSPHRASE }}",
         "PGP_SECRET"        -> "${{ secrets.PGP_SECRET }}",
@@ -1002,7 +1013,7 @@ object ZioSbtCiPlugin extends AutoPlugin {
 
     Step.SingleStep(
       name = "Publish Docs to NPM Registry",
-      run = Some(prefixJobs + s"sbt docs/${docsVersioning.npmCommand}")
+      run = Some(prefixJobs + SbtCommand + s" docs/${docsVersioning.npmCommand}")
     )
   }
 
@@ -1013,7 +1024,7 @@ object ZioSbtCiPlugin extends AutoPlugin {
 
     Step.SingleStep(
       name = "Generate Readme",
-      run = Some(prefixJobs + "sbt docs/generateReadme")
+      run = Some(prefixJobs + SbtCommand + " docs/generateReadme")
     )
   }
 
@@ -1024,7 +1035,7 @@ object ZioSbtCiPlugin extends AutoPlugin {
 
     Step.SingleStep(
       name = "Check if the README file is up to date",
-      run = Some(prefixJobs + "sbt docs/checkReadme")
+      run = Some(prefixJobs + SbtCommand + " docs/checkReadme")
     )
   }
 

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/bothPlugins/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/bothPlugins/expected/ci.yml
@@ -42,11 +42,11 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Check all code compiles
-      run: sbt +Test/compile
+      run: sbt --no-colors +Test/compile
     - name: Check artifacts build process
-      run: sbt +publishLocal
+      run: sbt --no-colors +publishLocal
     - name: Check website build process
-      run: sbt docs/clean; sbt docs/buildWebsite
+      run: sbt --no-colors docs/clean; sbt --no-colors docs/buildWebsite
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -69,9 +69,9 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Check if the site workflow is up to date
-      run: sbt ciCheckGithubWorkflow
+      run: sbt --no-colors ciCheckGithubWorkflow
     - name: Lint
-      run: sbt lint
+      run: sbt --no-colors lint
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -101,7 +101,7 @@ jobs:
       with:
         fetch-depth: '0'
     - name: Test
-      run: sbt +test
+      run: sbt --no-colors +test
   update-readme:
     name: Update README
     runs-on: ubuntu-latest
@@ -125,7 +125,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Generate Readme
-      run: sbt docs/generateReadme
+      run: sbt --no-colors docs/generateReadme
     - name: Commit Changes
       run: |
         git config --local user.email "zio-assistant[bot]@users.noreply.github.com"
@@ -206,7 +206,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Release
-      run: sbt ci-release
+      run: sbt --no-colors ci-release
       env:
         PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
         PGP_SECRET: ${{ secrets.PGP_SECRET }}
@@ -242,7 +242,7 @@ jobs:
         node-version: 24.12.0
         registry-url: https://registry.npmjs.org
     - name: Publish Docs to NPM Registry
-      run: sbt docs/publishToNpm
+      run: sbt --no-colors docs/publishToNpm
   notify-docs-release:
     name: Notify Docs Release
     runs-on: ubuntu-latest

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/concurrency/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/concurrency/expected/ci.yml
@@ -42,11 +42,11 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Check all code compiles
-      run: sbt +Test/compile
+      run: sbt --no-colors +Test/compile
     - name: Check artifacts build process
-      run: sbt +publishLocal
+      run: sbt --no-colors +publishLocal
     - name: Check website build process
-      run: sbt docs/clean; sbt docs/buildWebsite
+      run: sbt --no-colors docs/clean; sbt --no-colors docs/buildWebsite
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -69,9 +69,9 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Check if the site workflow is up to date
-      run: sbt ciCheckGithubWorkflow
+      run: sbt --no-colors ciCheckGithubWorkflow
     - name: Lint
-      run: sbt lint
+      run: sbt --no-colors lint
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -101,7 +101,7 @@ jobs:
       with:
         fetch-depth: '0'
     - name: Test
-      run: sbt +test
+      run: sbt --no-colors +test
   update-readme:
     name: Update README
     runs-on: ubuntu-latest
@@ -125,7 +125,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Generate Readme
-      run: sbt docs/generateReadme
+      run: sbt --no-colors docs/generateReadme
     - name: Commit Changes
       run: |
         git config --local user.email "zio-assistant[bot]@users.noreply.github.com"
@@ -236,7 +236,7 @@ jobs:
         node-version: 24.12.0
         registry-url: https://registry.npmjs.org
     - name: Publish Docs to NPM Registry
-      run: sbt docs/publishToNpm
+      run: sbt --no-colors docs/publishToNpm
   notify-docs-release:
     name: Notify Docs Release
     runs-on: ubuntu-latest

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/customJobs/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/customJobs/expected/ci.yml
@@ -79,9 +79,9 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Check if the site workflow is up to date
-      run: sbt ciCheckGithubWorkflow
+      run: sbt --no-colors ciCheckGithubWorkflow
     - name: Lint
-      run: sbt lint
+      run: sbt --no-colors lint
   integration-test:
     name: Integration Test
     runs-on: ubuntu-latest
@@ -129,7 +129,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Generate Readme
-      run: sbt docs/generateReadme
+      run: sbt --no-colors docs/generateReadme
     - name: Commit Changes
       run: |
         git config --local user.email "zio-assistant[bot]@users.noreply.github.com"
@@ -214,7 +214,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Release
-      run: sbt ci-release
+      run: sbt --no-colors ci-release
       env:
         PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
         PGP_SECRET: ${{ secrets.PGP_SECRET }}
@@ -254,7 +254,7 @@ jobs:
         node-version: 24.12.0
         registry-url: https://registry.npmjs.org
     - name: Publish Docs to NPM Registry
-      run: sbt docs/publishToNpm
+      run: sbt --no-colors docs/publishToNpm
   notify-docs-release:
     name: Notify Docs Release
     runs-on: ubuntu-latest

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/defaults/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/defaults/expected/ci.yml
@@ -42,11 +42,11 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Check all code compiles
-      run: sbt +Test/compile
+      run: sbt --no-colors +Test/compile
     - name: Check artifacts build process
-      run: sbt +publishLocal
+      run: sbt --no-colors +publishLocal
     - name: Check website build process
-      run: sbt docs/clean; sbt docs/buildWebsite
+      run: sbt --no-colors docs/clean; sbt --no-colors docs/buildWebsite
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -69,9 +69,9 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Check if the site workflow is up to date
-      run: sbt ciCheckGithubWorkflow
+      run: sbt --no-colors ciCheckGithubWorkflow
     - name: Lint
-      run: sbt lint
+      run: sbt --no-colors lint
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -101,7 +101,7 @@ jobs:
       with:
         fetch-depth: '0'
     - name: Test
-      run: sbt +test
+      run: sbt --no-colors +test
   update-readme:
     name: Update README
     runs-on: ubuntu-latest
@@ -125,7 +125,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Generate Readme
-      run: sbt docs/generateReadme
+      run: sbt --no-colors docs/generateReadme
     - name: Commit Changes
       run: |
         git config --local user.email "zio-assistant[bot]@users.noreply.github.com"
@@ -206,7 +206,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Release
-      run: sbt ci-release
+      run: sbt --no-colors ci-release
       env:
         PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
         PGP_SECRET: ${{ secrets.PGP_SECRET }}
@@ -242,7 +242,7 @@ jobs:
         node-version: 24.12.0
         registry-url: https://registry.npmjs.org
     - name: Publish Docs to NPM Registry
-      run: sbt docs/publishToNpm
+      run: sbt --no-colors docs/publishToNpm
   notify-docs-release:
     name: Notify Docs Release
     runs-on: ubuntu-latest

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/flattenTests/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/flattenTests/expected/ci.yml
@@ -42,11 +42,11 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Check all code compiles
-      run: sbt +Test/compile
+      run: sbt --no-colors +Test/compile
     - name: Check artifacts build process
-      run: sbt +publishLocal
+      run: sbt --no-colors +publishLocal
     - name: Check website build process
-      run: sbt docs/clean; sbt docs/buildWebsite
+      run: sbt --no-colors docs/clean; sbt --no-colors docs/buildWebsite
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -69,9 +69,9 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Check if the site workflow is up to date
-      run: sbt ciCheckGithubWorkflow
+      run: sbt --no-colors ciCheckGithubWorkflow
     - name: Lint
-      run: sbt lint
+      run: sbt --no-colors lint
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -105,7 +105,7 @@ jobs:
       with:
         fetch-depth: '0'
     - name: Test
-      run: sbt ${{ matrix.scala-project }}/test
+      run: sbt --no-colors ${{ matrix.scala-project }}/test
   update-readme:
     name: Update README
     runs-on: ubuntu-latest
@@ -129,7 +129,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Generate Readme
-      run: sbt docs/generateReadme
+      run: sbt --no-colors docs/generateReadme
     - name: Commit Changes
       run: |
         git config --local user.email "zio-assistant[bot]@users.noreply.github.com"
@@ -210,7 +210,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Release
-      run: sbt ci-release
+      run: sbt --no-colors ci-release
       env:
         PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
         PGP_SECRET: ${{ secrets.PGP_SECRET }}
@@ -246,7 +246,7 @@ jobs:
         node-version: 24.12.0
         registry-url: https://registry.npmjs.org
     - name: Publish Docs to NPM Registry
-      run: sbt docs/publishToNpm
+      run: sbt --no-colors docs/publishToNpm
   notify-docs-release:
     name: Notify Docs Release
     runs-on: ubuntu-latest

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/groupTests/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/groupTests/expected/ci.yml
@@ -42,11 +42,11 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Check all code compiles
-      run: sbt +Test/compile
+      run: sbt --no-colors +Test/compile
     - name: Check artifacts build process
-      run: sbt +publishLocal
+      run: sbt --no-colors +publishLocal
     - name: Check website build process
-      run: sbt docs/clean; sbt docs/buildWebsite
+      run: sbt --no-colors docs/clean; sbt --no-colors docs/buildWebsite
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -69,9 +69,9 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Check if the site workflow is up to date
-      run: sbt ciCheckGithubWorkflow
+      run: sbt --no-colors ciCheckGithubWorkflow
     - name: Lint
-      run: sbt lint
+      run: sbt --no-colors lint
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -104,13 +104,13 @@ jobs:
         fetch-depth: '0'
     - name: Test
       if: ${{ (matrix.java == '17') && (matrix.scala == '2.13.16') }}
-      run: 'sbt ++${{ matrix.scala }} moduleA/test '
+      run: 'sbt --no-colors ++${{ matrix.scala }} moduleA/test '
     - name: Test
       if: ${{ (matrix.java == '21') && (matrix.scala == '2.13.16') }}
-      run: 'sbt ++${{ matrix.scala }} moduleA/test  moduleB/test '
+      run: 'sbt --no-colors ++${{ matrix.scala }} moduleA/test  moduleB/test '
     - name: Test
       if: ${{ (matrix.java == '21') && (matrix.scala == '3.3.4') }}
-      run: 'sbt ++${{ matrix.scala }} moduleB/test '
+      run: 'sbt --no-colors ++${{ matrix.scala }} moduleB/test '
   update-readme:
     name: Update README
     runs-on: ubuntu-latest
@@ -134,7 +134,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Generate Readme
-      run: sbt docs/generateReadme
+      run: sbt --no-colors docs/generateReadme
     - name: Commit Changes
       run: |
         git config --local user.email "zio-assistant[bot]@users.noreply.github.com"
@@ -215,7 +215,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Release
-      run: sbt ci-release
+      run: sbt --no-colors ci-release
       env:
         PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
         PGP_SECRET: ${{ secrets.PGP_SECRET }}
@@ -251,7 +251,7 @@ jobs:
         node-version: 24.12.0
         registry-url: https://registry.npmjs.org
     - name: Publish Docs to NPM Registry
-      run: sbt docs/publishToNpm
+      run: sbt --no-colors docs/publishToNpm
   notify-docs-release:
     name: Notify Docs Release
     runs-on: ubuntu-latest

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/mappedJobs/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/mappedJobs/expected/ci.yml
@@ -42,11 +42,11 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Check all code compiles
-      run: sbt +Test/compile
+      run: sbt --no-colors +Test/compile
     - name: Check artifacts build process
-      run: sbt +publishLocal
+      run: sbt --no-colors +publishLocal
     - name: Check website build process
-      run: sbt docs/clean; sbt docs/buildWebsite
+      run: sbt --no-colors docs/clean; sbt --no-colors docs/buildWebsite
   lint:
     name: Lint
     runs-on: ubuntu-22.04
@@ -69,9 +69,9 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Check if the site workflow is up to date
-      run: sbt ciCheckGithubWorkflow
+      run: sbt --no-colors ciCheckGithubWorkflow
     - name: Lint
-      run: sbt lint
+      run: sbt --no-colors lint
   test:
     name: Test
     runs-on: ubuntu-22.04
@@ -101,7 +101,7 @@ jobs:
       with:
         fetch-depth: '0'
     - name: Test
-      run: sbt +test
+      run: sbt --no-colors +test
   compile-examples:
     name: Compile Examples
     runs-on: ubuntu-22.04
@@ -150,7 +150,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Generate Readme
-      run: sbt docs/generateReadme
+      run: sbt --no-colors docs/generateReadme
     - name: Commit Changes
       run: |
         git config --local user.email "zio-assistant[bot]@users.noreply.github.com"
@@ -232,7 +232,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Release
-      run: sbt ci-release
+      run: sbt --no-colors ci-release
       env:
         PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
         PGP_SECRET: ${{ secrets.PGP_SECRET }}
@@ -268,7 +268,7 @@ jobs:
         node-version: 24.12.0
         registry-url: https://registry.npmjs.org
     - name: Publish Docs to NPM Registry
-      run: sbt docs/publishToNpm
+      run: sbt --no-colors docs/publishToNpm
   notify-docs-release:
     name: Notify Docs Release
     runs-on: ubuntu-22.04

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/services/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/services/expected/ci.yml
@@ -42,11 +42,11 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Check all code compiles
-      run: sbt +Test/compile
+      run: sbt --no-colors +Test/compile
     - name: Check artifacts build process
-      run: sbt +publishLocal
+      run: sbt --no-colors +publishLocal
     - name: Check website build process
-      run: sbt docs/clean; sbt docs/buildWebsite
+      run: sbt --no-colors docs/clean; sbt --no-colors docs/buildWebsite
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -69,9 +69,9 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Check if the site workflow is up to date
-      run: sbt ciCheckGithubWorkflow
+      run: sbt --no-colors ciCheckGithubWorkflow
     - name: Lint
-      run: sbt lint
+      run: sbt --no-colors lint
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -131,7 +131,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Generate Readme
-      run: sbt docs/generateReadme
+      run: sbt --no-colors docs/generateReadme
     - name: Commit Changes
       run: |
         git config --local user.email "zio-assistant[bot]@users.noreply.github.com"
@@ -212,7 +212,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Release
-      run: sbt ci-release
+      run: sbt --no-colors ci-release
       env:
         PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
         PGP_SECRET: ${{ secrets.PGP_SECRET }}
@@ -248,7 +248,7 @@ jobs:
         node-version: 24.12.0
         registry-url: https://registry.npmjs.org
     - name: Publish Docs to NPM Registry
-      run: sbt docs/publishToNpm
+      run: sbt --no-colors docs/publishToNpm
   notify-docs-release:
     name: Notify Docs Release
     runs-on: ubuntu-latest

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/settingsOverrides/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/settingsOverrides/expected/ci.yml
@@ -46,11 +46,11 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Check all code compiles
-      run: sbt +Test/compile
+      run: sbt --no-colors +Test/compile
     - name: Check artifacts build process
-      run: sbt +publishLocal
+      run: sbt --no-colors +publishLocal
     - name: Check website build process
-      run: sbt docs/clean; sbt docs/buildWebsite
+      run: sbt --no-colors docs/clean; sbt --no-colors docs/buildWebsite
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -73,9 +73,9 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Check if the site workflow is up to date
-      run: sbt ciCheckGithubWorkflow
+      run: sbt --no-colors ciCheckGithubWorkflow
     - name: Lint
-      run: sbt lint
+      run: sbt --no-colors lint
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -104,7 +104,7 @@ jobs:
       with:
         fetch-depth: '0'
     - name: Test
-      run: sbt +test
+      run: sbt --no-colors +test
   update-readme:
     name: Update README
     runs-on: ubuntu-latest
@@ -128,7 +128,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Generate Readme
-      run: sbt docs/generateReadme
+      run: sbt --no-colors docs/generateReadme
     - name: Commit Changes
       run: |
         git config --local user.email "zio-assistant[bot]@users.noreply.github.com"
@@ -209,7 +209,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Release
-      run: sbt ci-release
+      run: sbt --no-colors ci-release
       env:
         PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
         PGP_SECRET: ${{ secrets.PGP_SECRET }}
@@ -245,7 +245,7 @@ jobs:
         node-version: 24.12.0
         registry-url: https://registry.npmjs.org
     - name: Publish Docs to NPM Registry
-      run: sbt docs/publishToNpm
+      run: sbt --no-colors docs/publishToNpm
   notify-docs-release:
     name: Notify Docs Release
     runs-on: ubuntu-latest

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowEnv/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowEnv/expected/ci.yml
@@ -42,11 +42,11 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Check all code compiles
-      run: sbt +Test/compile
+      run: sbt --no-colors +Test/compile
     - name: Check artifacts build process
-      run: sbt +publishLocal
+      run: sbt --no-colors +publishLocal
     - name: Check website build process
-      run: sbt docs/clean; sbt docs/buildWebsite
+      run: sbt --no-colors docs/clean; sbt --no-colors docs/buildWebsite
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -69,9 +69,9 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Check if the site workflow is up to date
-      run: sbt ciCheckGithubWorkflow
+      run: sbt --no-colors ciCheckGithubWorkflow
     - name: Lint
-      run: sbt lint
+      run: sbt --no-colors lint
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -101,7 +101,7 @@ jobs:
       with:
         fetch-depth: '0'
     - name: Test
-      run: sbt +test
+      run: sbt --no-colors +test
   update-readme:
     name: Update README
     runs-on: ubuntu-latest
@@ -125,7 +125,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Generate Readme
-      run: sbt docs/generateReadme
+      run: sbt --no-colors docs/generateReadme
     - name: Commit Changes
       run: |
         git config --local user.email "zio-assistant[bot]@users.noreply.github.com"
@@ -206,7 +206,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Release
-      run: sbt ci-release
+      run: sbt --no-colors ci-release
       env:
         PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
         PGP_SECRET: ${{ secrets.PGP_SECRET }}
@@ -242,7 +242,7 @@ jobs:
         node-version: 24.12.0
         registry-url: https://registry.npmjs.org
     - name: Publish Docs to NPM Registry
-      run: sbt docs/publishToNpm
+      run: sbt --no-colors docs/publishToNpm
   notify-docs-release:
     name: Notify Docs Release
     runs-on: ubuntu-latest

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowTriggers/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowTriggers/expected/ci.yml
@@ -41,11 +41,11 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Check all code compiles
-      run: sbt +Test/compile
+      run: sbt --no-colors +Test/compile
     - name: Check artifacts build process
-      run: sbt +publishLocal
+      run: sbt --no-colors +publishLocal
     - name: Check website build process
-      run: sbt docs/clean; sbt docs/buildWebsite
+      run: sbt --no-colors docs/clean; sbt --no-colors docs/buildWebsite
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -68,9 +68,9 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Check if the site workflow is up to date
-      run: sbt ciCheckGithubWorkflow
+      run: sbt --no-colors ciCheckGithubWorkflow
     - name: Lint
-      run: sbt lint
+      run: sbt --no-colors lint
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -100,7 +100,7 @@ jobs:
       with:
         fetch-depth: '0'
     - name: Test
-      run: sbt +test
+      run: sbt --no-colors +test
   update-readme:
     name: Update README
     runs-on: ubuntu-latest
@@ -124,7 +124,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Generate Readme
-      run: sbt docs/generateReadme
+      run: sbt --no-colors docs/generateReadme
     - name: Commit Changes
       run: |
         git config --local user.email "zio-assistant[bot]@users.noreply.github.com"
@@ -205,7 +205,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v8.1.1
     - name: Release
-      run: sbt ci-release
+      run: sbt --no-colors ci-release
       env:
         PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
         PGP_SECRET: ${{ secrets.PGP_SECRET }}
@@ -241,7 +241,7 @@ jobs:
         node-version: 24.12.0
         registry-url: https://registry.npmjs.org
     - name: Publish Docs to NPM Registry
-      run: sbt docs/publishToNpm
+      run: sbt --no-colors docs/publishToNpm
   notify-docs-release:
     name: Notify Docs Release
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes #748.

## Problem

sbt colourises its `[error]` and `[warn]` prefixes, so those tokens never appear literally in a CI log. A real line from a failing `zio/zio-blocks` job:

```
^[[0m[^[[0m^[[31merror^[[0m] ^[[0m^[[0mType error in expression^[[0m
```

`gh run view --log-failed | grep '[error]'` comes back empty on a job that failed with sbt errors, and GitHub's in-browser log search has the same blind spot. Plain scalac output in the same log is *not* colourised, so a log can show a readable `error:` line next to an unreadable `[error]` line, which makes a failure look half-reported.

## Change

Every generated invocation now goes through one constant:

```scala
private val SbtCommand = "sbt --no-colors"
```

14 call sites updated, so `run: sbt +test` becomes `run: sbt --no-colors +test` and so on.

## Why not the env default the issue proposed

The issue suggested adding `-Dsbt.log.noformat=true` to the `ciWorkflowEnv` default, and that turns out to be the weaker option. Assigning `ciWorkflowEnv` replaces the derived map outright — which is exactly how a build opts out of `JDK_JAVA_OPTIONS` in favour of `SBT_OPTS`, as documented in the `workflowEnv` scripted fixture:

> By default the plugin exports JDK_JAVA_OPTIONS, but that is not always safe: it makes `java -version` print a NOTE containing commas, which corrupts the cache keys computed by setup-sbt and coursier/cache-action.

`zio/zio-blocks` is one such build, so an env-based default would have missed the very repo that motivated the issue. A flag on the command line reaches every generated step regardless of how the build configures its environment.

## Verification

sbt 1.12.15, Java 21.0.9, on a project whose `build.sbt` fails to compile, stdin closed to mimic CI:

| invocation | exit | ANSI escapes in log |
|---|---|---|
| `sbt "print name"` | 1 | 7 |
| `sbt --no-colors "print name"` | 1 | 0 |
| `JDK_JAVA_OPTIONS=… -Dsbt.log.noformat=true sbt "print name"` | 1 | 0 |

For completeness, `-Dsbt.ci=true` does not help (still 7).

In-repo:

- `sbt zio-sbt-ci/test` — all 13 scripted fixtures pass. The 11 golden `expected/ci.yml` files were re-recorded via the fixtures' own self-bootstrapping path (delete the golden, re-run, copy the recording), and every changed line in them is a `run:` line.
- `sbt lint` — passes.
- `sbt ciCheckGithubWorkflow` — passes; this repo's own `.github/workflows/ci.yml` is regenerated in the same commit.
- `docs/index.md` and `README.md` sample YAML updated to match the new output.

## Notes

- `docs/checkReadme` fails on unmodified `main` as well (the committed README still says `0.6.3` while `0.7.0` is released), so I left that alone rather than folding unrelated version bumps into this PR. Worth knowing that `checkReadme` regenerates `README.md` in place as a side effect.
- `ScalaWorkflow.runSBT` in `zio-sbt-githubactions` also builds an `sbt …` string, but nothing references it, so I left it untouched.
