### PR TITLE
fix(ci): grant the update-readme job permission to approve its pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,9 @@ jobs:
   update-readme:
     name: Update README
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     continue-on-error: false
     if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
     steps:

--- a/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
+++ b/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
@@ -412,6 +412,13 @@ object ZioSbtCiPlugin extends AutoPlugin {
       Job(
         id = "update-readme",
         name = "Update README",
+        // The "Approve PR" and "Enable Auto-Merge" steps call `gh` with GITHUB_TOKEN, which
+        // needs `pull-requests: write`. The workflow-level default is `contents: read` plus
+        // `id-token: write`, so without this the approve step fails with
+        // "GraphQL: Resource not accessible by integration (addPullRequestReview)" after the
+        // pull request has already been opened. Job-level permissions replace the
+        // workflow-level set, so `contents: read` has to be repeated here for the checkout.
+        permissions = Map("contents" -> "read", "pull-requests" -> "write"),
         condition = updateReadmeCondition orElse Some(
           Condition.Expression("github.event_name == 'release'") &&
             Condition.Expression("github.event.action == 'published'")

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/bothPlugins/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/bothPlugins/expected/ci.yml
@@ -105,6 +105,9 @@ jobs:
   update-readme:
     name: Update README
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     continue-on-error: false
     if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
     steps:

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/concurrency/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/concurrency/expected/ci.yml
@@ -105,6 +105,9 @@ jobs:
   update-readme:
     name: Update README
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     continue-on-error: false
     if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
     steps:

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/customJobs/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/customJobs/expected/ci.yml
@@ -105,6 +105,9 @@ jobs:
   update-readme:
     name: Update README
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     continue-on-error: false
     if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
     steps:

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/defaults/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/defaults/expected/ci.yml
@@ -105,6 +105,9 @@ jobs:
   update-readme:
     name: Update README
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     continue-on-error: false
     if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
     steps:

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/flattenTests/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/flattenTests/expected/ci.yml
@@ -109,6 +109,9 @@ jobs:
   update-readme:
     name: Update README
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     continue-on-error: false
     if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
     steps:

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/groupTests/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/groupTests/expected/ci.yml
@@ -114,6 +114,9 @@ jobs:
   update-readme:
     name: Update README
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     continue-on-error: false
     if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
     steps:

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/mappedJobs/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/mappedJobs/expected/ci.yml
@@ -130,6 +130,9 @@ jobs:
   update-readme:
     name: Update README
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      pull-requests: write
     continue-on-error: false
     if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
     steps:

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/services/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/services/expected/ci.yml
@@ -111,6 +111,9 @@ jobs:
   update-readme:
     name: Update README
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     continue-on-error: false
     if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
     steps:

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/settingsOverrides/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/settingsOverrides/expected/ci.yml
@@ -108,6 +108,9 @@ jobs:
   update-readme:
     name: Update README
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     continue-on-error: false
     if: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
     steps:

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowEnv/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowEnv/expected/ci.yml
@@ -105,6 +105,9 @@ jobs:
   update-readme:
     name: Update README
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     continue-on-error: false
     if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
     steps:

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowTriggers/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowTriggers/expected/ci.yml
@@ -104,6 +104,9 @@ jobs:
   update-readme:
     name: Update README
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     continue-on-error: false
     if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
     steps:

--- a/zio-sbt-githubactions/src/main/scala/zio/sbt/githubactions/model.scala
+++ b/zio-sbt-githubactions/src/main/scala/zio/sbt/githubactions/model.scala
@@ -425,8 +425,12 @@ case class Job private (
   services: Chunk[Service],
   condition: Option[Condition],
   jobTimeout: Option[Int],
-  concurrency: Option[Concurrency]
+  concurrency: Option[Concurrency],
+  permissions: Map[String, String]
 ) {
+  def withPermissions(permissions: (String, String)*): Job =
+    copy(permissions = permissions.toMap)
+
   def withStrategy(strategy: Strategy): Job =
     copy(strategy = Some(strategy))
 
@@ -465,7 +469,8 @@ object Job {
     services: Seq[Service] = Seq.empty,
     condition: Option[Condition] = None,
     jobTimeout: Option[Int] = None,
-    concurrency: Option[Concurrency] = None
+    concurrency: Option[Concurrency] = None,
+    permissions: Map[String, String] = Map.empty
   ): Job = Job(
     id = id,
     name = name,
@@ -478,7 +483,8 @@ object Job {
     services = Chunk.fromIterable(services),
     condition = condition,
     jobTimeout = jobTimeout,
-    concurrency = concurrency
+    concurrency = concurrency,
+    permissions = permissions
   )
 
   /**
@@ -503,6 +509,9 @@ object Job {
       Json.Obj(
         ("name", Json.Str(job.name)),
         ("runs-on", Json.Str(job.runsOn)),
+        // Job-level permissions replace the workflow-level ones for this job, so only
+        // render them when a job actually asks for a different set.
+        ("permissions", if (job.permissions.nonEmpty) job.permissions.toJsonAST.getOrElse(Json.Null) else Json.Null),
         ("timeout-minutes", timeoutOf(job).toJsonAST.getOrElse(Json.Null)),
         ("concurrency", job.concurrency.toJsonAST.getOrElse(Json.Null)),
         ("continue-on-error", Json.Bool(job.continueOnError)),


### PR DESCRIPTION
## Problem

The `update-readme` job's last two steps call `gh` with `GITHUB_TOKEN`:

```yaml
- name: Approve PR
  run: gh pr review "$PR_URL" --approve
- name: Enable Auto-Merge
  run: gh pr merge --auto --squash "$PR_URL" || gh pr merge --squash "$PR_URL"
```

Both need `pull-requests: write`. The generated workflow declares only the default set — `contents: read` and `id-token: write` — so the approve step fails:

```
failed to create review: GraphQL: Resource not accessible by integration (addPullRequestReview)
##[error]Process completed with exit code 1.
```

By that point the pull request has already been opened, so the visible result is a red release run plus a README PR that is never approved and never auto-merges. It just sits there waiting for a human, which defeats the point of the job.

Observed on zio-dynamodb's `v1.0.0-RC27` release run — every other job in that run was green.

## Change

Grant the permission on the job rather than the workflow.

Job-level permissions **replace** the workflow-level set rather than adding to it, so `contents: read` is repeated alongside the new grant for the checkout, and every other job keeps the workflow default untouched:

```yaml
  update-readme:
    name: Update README
    runs-on: ubuntu-latest
    permissions:
      contents: read
      pull-requests: write
```

Granting it at the workflow level instead would hand `pull-requests: write` to `build`, `test` and `release` as well, none of which need it.

`Job` had no `permissions` field, so this adds one to the model. It renders only when a job sets a non-empty map, which leaves every other generated job byte-identical — the only diff in the golden files is the three-line block above.

Note the `auto-approve` and `auto-merge` workflows were already correct; they declare `pull-requests: write` at the workflow level because every job in them needs it.

## Verification

- `zio-sbt-ci/scripted` passes across all thirteen test projects.
- The eleven golden `ci.yml` files that contain an `update-readme` job gain exactly the new block and nothing else.
- `scalafmtCheckAll` and `scalafmtSbtCheck` pass.
