### PR TITLE
fix(ci): grant pull-requests:write to the update-readme job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,9 @@ jobs:
     name: Update README
     runs-on: ubuntu-latest
     continue-on-error: false
+    permissions:
+      contents: write
+      pull-requests: write
     if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
     steps:
     - name: Git Checkout

--- a/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
+++ b/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
@@ -412,6 +412,12 @@ object ZioSbtCiPlugin extends AutoPlugin {
       Job(
         id = "update-readme",
         name = "Update README",
+        // The workflow-level `permissions` block only grants `id-token`/`contents: read`, so
+        // without this, `Approve PR`/`Enable Auto-Merge` below fail with "Resource not
+        // accessible by integration": an explicit `permissions` block replaces the repo's
+        // default grants entirely rather than adding to them, and GITHUB_TOKEN ends up with no
+        // pull-requests scope at all.
+        permissions = Map("contents" -> "write", "pull-requests" -> "write"),
         condition = updateReadmeCondition orElse Some(
           Condition.Expression("github.event_name == 'release'") &&
             Condition.Expression("github.event.action == 'published'")

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/bothPlugins/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/bothPlugins/expected/ci.yml
@@ -106,6 +106,9 @@ jobs:
     name: Update README
     runs-on: ubuntu-latest
     continue-on-error: false
+    permissions:
+      contents: write
+      pull-requests: write
     if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
     steps:
     - name: Git Checkout

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/concurrency/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/concurrency/expected/ci.yml
@@ -106,6 +106,9 @@ jobs:
     name: Update README
     runs-on: ubuntu-latest
     continue-on-error: false
+    permissions:
+      contents: write
+      pull-requests: write
     if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
     steps:
     - name: Git Checkout

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/customJobs/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/customJobs/expected/ci.yml
@@ -106,6 +106,9 @@ jobs:
     name: Update README
     runs-on: ubuntu-latest
     continue-on-error: false
+    permissions:
+      contents: write
+      pull-requests: write
     if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
     steps:
     - name: Set Swap Space

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/defaults/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/defaults/expected/ci.yml
@@ -106,6 +106,9 @@ jobs:
     name: Update README
     runs-on: ubuntu-latest
     continue-on-error: false
+    permissions:
+      contents: write
+      pull-requests: write
     if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
     steps:
     - name: Git Checkout

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/flattenTests/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/flattenTests/expected/ci.yml
@@ -110,6 +110,9 @@ jobs:
     name: Update README
     runs-on: ubuntu-latest
     continue-on-error: false
+    permissions:
+      contents: write
+      pull-requests: write
     if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
     steps:
     - name: Git Checkout

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/groupTests/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/groupTests/expected/ci.yml
@@ -115,6 +115,9 @@ jobs:
     name: Update README
     runs-on: ubuntu-latest
     continue-on-error: false
+    permissions:
+      contents: write
+      pull-requests: write
     if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
     steps:
     - name: Git Checkout

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/mappedJobs/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/mappedJobs/expected/ci.yml
@@ -131,6 +131,9 @@ jobs:
     name: Update README
     runs-on: ubuntu-22.04
     continue-on-error: false
+    permissions:
+      contents: write
+      pull-requests: write
     if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
     steps:
     - name: Git Checkout

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/services/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/services/expected/ci.yml
@@ -112,6 +112,9 @@ jobs:
     name: Update README
     runs-on: ubuntu-latest
     continue-on-error: false
+    permissions:
+      contents: write
+      pull-requests: write
     if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
     steps:
     - name: Git Checkout

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/settingsOverrides/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/settingsOverrides/expected/ci.yml
@@ -109,6 +109,9 @@ jobs:
     name: Update README
     runs-on: ubuntu-latest
     continue-on-error: false
+    permissions:
+      contents: write
+      pull-requests: write
     if: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
     steps:
     - name: Git Checkout

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowEnv/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowEnv/expected/ci.yml
@@ -106,6 +106,9 @@ jobs:
     name: Update README
     runs-on: ubuntu-latest
     continue-on-error: false
+    permissions:
+      contents: write
+      pull-requests: write
     if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
     steps:
     - name: Git Checkout

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowTriggers/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowTriggers/expected/ci.yml
@@ -105,6 +105,9 @@ jobs:
     name: Update README
     runs-on: ubuntu-latest
     continue-on-error: false
+    permissions:
+      contents: write
+      pull-requests: write
     if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
     steps:
     - name: Git Checkout

--- a/zio-sbt-githubactions/src/main/scala/zio/sbt/githubactions/model.scala
+++ b/zio-sbt-githubactions/src/main/scala/zio/sbt/githubactions/model.scala
@@ -425,7 +425,8 @@ case class Job private (
   services: Chunk[Service],
   condition: Option[Condition],
   jobTimeout: Option[Int],
-  concurrency: Option[Concurrency]
+  concurrency: Option[Concurrency],
+  permissions: Map[String, String]
 ) {
   def withStrategy(strategy: Strategy): Job =
     copy(strategy = Some(strategy))
@@ -438,6 +439,9 @@ case class Job private (
 
   def withTimeout(minutes: Int): Job =
     copy(jobTimeout = Some(minutes))
+
+  def withPermissions(permissions: (String, String)*): Job =
+    copy(permissions = permissions.toMap)
 }
 
 object Job {
@@ -465,7 +469,8 @@ object Job {
     services: Seq[Service] = Seq.empty,
     condition: Option[Condition] = None,
     jobTimeout: Option[Int] = None,
-    concurrency: Option[Concurrency] = None
+    concurrency: Option[Concurrency] = None,
+    permissions: Map[String, String] = Map.empty
   ): Job = Job(
     id = id,
     name = name,
@@ -478,7 +483,8 @@ object Job {
     services = Chunk.fromIterable(services),
     condition = condition,
     jobTimeout = jobTimeout,
-    concurrency = concurrency
+    concurrency = concurrency,
+    permissions = permissions
   )
 
   /**
@@ -506,6 +512,10 @@ object Job {
         ("timeout-minutes", timeoutOf(job).toJsonAST.getOrElse(Json.Null)),
         ("concurrency", job.concurrency.toJsonAST.getOrElse(Json.Null)),
         ("continue-on-error", Json.Bool(job.continueOnError)),
+        (
+          "permissions",
+          if (job.permissions.nonEmpty) job.permissions.toJsonAST.getOrElse(Json.Null) else Json.Null
+        ),
         ("strategy", job.strategy.toJsonAST.getOrElse(Json.Null)),
         ("needs", if (job.need.nonEmpty) job.need.toJsonAST.getOrElse(Json.Null) else Json.Null),
         ("services", servicesJson),


### PR DESCRIPTION
## Problem

Found while adopting `zio-sbt-ci` in `zio/zio-cli`: the `update-readme` job's `Approve PR` step fails whenever the job actually creates a new README PR:

```
failed to create review: GraphQL: Resource not accessible by integration (addPullRequestReview)
```

Example: https://github.com/zio/zio-cli/actions/runs/32732617378/job/97448048020

## Root cause

The generated `ci.yml`'s workflow-level `permissions:` block only grants:
```yaml
permissions:
  id-token: write
  contents: read
```
(`Workflow.defaultPermissions`). GitHub Actions treats an explicit `permissions:` block as a full replacement of the repo's default token grants, not an addition — so `GITHUB_TOKEN` in every job of this workflow has **zero** `pull-requests` scope, no matter what the repo's own "Allow GitHub Actions to create and approve pull requests" setting says.

`update-readme`'s `Approve PR` and `Enable Auto-Merge` steps call `gh pr review --approve` / `gh pr merge` with `GITHUB_TOKEN`, which needs `pull-requests: write` — never granted.

I couldn't find a run in `zio-sbt`'s own history where this job created a *new* PR and reached the approve step (every one I checked had `pull-request-operation: none`, i.e. nothing to commit), so this bug has been latent here too.

## Fix

Added a `permissions` field to the `Job` model (`zio-sbt-githubactions`), defaulting to empty so no other generated job changes at all, and set `contents: write, pull-requests: write` on just the `update-readme` job — scoped to the one job that needs it rather than loosening the whole workflow's token.

## Test plan

- [x] `sbt ciGenerateGithubWorkflow` regenerates only `update-readme` in this repo's own `ci.yml`, adding the 3-line `permissions` block (dogfooded — see diff)
- [x] Updated all 11 `zio-sbt-ci` scripted-test golden files (`expected/ci.yml`) that render this job
- [x] All 11 `zio-sbt-ci` scripted tests pass (`sbt "zio-sbt-ci/scripted zio-sbt-ci/<fixture>"` for each)
- [x] `sbt fmt lint` clean