### PR TITLE
fix(ci): tighten update-readme's contents permission to read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: false
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
     if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
     steps:

--- a/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
+++ b/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
@@ -414,10 +414,11 @@ object ZioSbtCiPlugin extends AutoPlugin {
         name = "Update README",
         // The workflow-level `permissions` block only grants `id-token`/`contents: read`, so
         // without this, `Approve PR`/`Enable Auto-Merge` below fail with "Resource not
-        // accessible by integration": an explicit `permissions` block replaces the repo's
-        // default grants entirely rather than adding to them, and GITHUB_TOKEN ends up with no
-        // pull-requests scope at all.
-        permissions = Map("contents" -> "write", "pull-requests" -> "write"),
+        // accessible by integration": a job-level `permissions` block replaces the workflow's
+        // grants entirely rather than adding to them, so `contents: read` has to be repeated
+        // here for the checkout step - the job never pushes with GITHUB_TOKEN, the actual
+        // commit/PR push uses the separate GitHub App token from `Generate Token` below.
+        permissions = Map("contents" -> "read", "pull-requests" -> "write"),
         condition = updateReadmeCondition orElse Some(
           Condition.Expression("github.event_name == 'release'") &&
             Condition.Expression("github.event.action == 'published'")

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/bothPlugins/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/bothPlugins/expected/ci.yml
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: false
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
     if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
     steps:

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/concurrency/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/concurrency/expected/ci.yml
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: false
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
     if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
     steps:

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/customJobs/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/customJobs/expected/ci.yml
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: false
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
     if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
     steps:

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/defaults/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/defaults/expected/ci.yml
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: false
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
     if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
     steps:

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/flattenTests/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/flattenTests/expected/ci.yml
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: false
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
     if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
     steps:

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/groupTests/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/groupTests/expected/ci.yml
@@ -116,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: false
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
     if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
     steps:

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/mappedJobs/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/mappedJobs/expected/ci.yml
@@ -132,7 +132,7 @@ jobs:
     runs-on: ubuntu-22.04
     continue-on-error: false
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
     if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
     steps:

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/services/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/services/expected/ci.yml
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: false
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
     if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
     steps:

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/settingsOverrides/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/settingsOverrides/expected/ci.yml
@@ -110,7 +110,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: false
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
     if: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
     steps:

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowEnv/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowEnv/expected/ci.yml
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: false
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
     if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
     steps:

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowTriggers/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowTriggers/expected/ci.yml
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: false
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
     if: ${{ (github.event_name == 'release') && (github.event.action == 'published') }}
     steps:


### PR DESCRIPTION
## Follow-up to #757

#757 fixed the "Resource not accessible by integration" failure on `update-readme` by granting:
```yaml
permissions:
  contents: write
  pull-requests: write
```
`contents: write` is unnecessary — the job never pushes with `GITHUB_TOKEN`. The actual commit gets pushed via `peter-evans/create-pull-request` using the separate GitHub App token minted by the `Generate Token` step earlier in the same job. `contents: read` (needed only for the checkout step) is enough.

This matches what #756 — an independent, earlier fix for the same underlying bug — already had right; #756 is now closed as superseded by #757, and this closes the one real gap between the two.

## Test plan

- [x] `sbt ciGenerateGithubWorkflow` changes exactly one line in this repo's own `ci.yml` (`contents: write` → `read`)
- [x] All 11 `zio-sbt-ci` scripted tests pass with their golden files updated to match
- [x] `sbt fmt lint` clean