### PR TITLE
chore(website): scaffold from create-zio-website 0.1.0

### DIFF
--- a/zio-sbt-website/src/main/scala/zio/sbt/WebsitePlugin.scala
+++ b/zio-sbt-website/src/main/scala/zio/sbt/WebsitePlugin.scala
@@ -151,7 +151,7 @@ object WebsitePlugin extends sbt.AutoPlugin {
       ciWorkflowName          := "CI",
       docsVersioningScheme    := VersioningScheme.SemanticVersioning,
       docsVersion             := docsVersionTask.value,
-      createZioWebsiteVersion := "0.0.1-alpha.14"
+      createZioWebsiteVersion := "0.1.0"
     )
 
   private def exit(exitCode: Int, errorMessage: String = "") = if (exitCode != 0) sys.error(errorMessage: String)

--- a/zio-sbt-website/src/sbt-test/zio-sbt-website/installWebsite/build.sbt
+++ b/zio-sbt-website/src/sbt-test/zio-sbt-website/installWebsite/build.sbt
@@ -8,9 +8,10 @@ lazy val root = (project in file("."))
     mainModuleName := "test-project",
     projectStage   := ProjectStage.ProductionReady,
 
-    // create-zio-website still scaffolds Docusaurus 2.1.0, which needs webpack pinned to 5.75.0.
-    // The pin is conditional on the scaffolded major version, so assert it is actually applied
-    // here; if the scaffold ever moves to Docusaurus 3, this expectation flips to `absent`.
+    // create-zio-website 0.1.0 scaffolds Docusaurus 3.10.2, which depends on webpack ^5.95.0 and
+    // must NOT carry the 5.75.0 pin -- that constraint is unsatisfiable and fails `npm install`
+    // with ERESOLVE. The pin is conditional on the scaffolded major version, so this asserts it
+    // is absent here, and would flip back to requiring it on a Docusaurus 2 scaffold.
     TaskKey[Unit]("checkWebpackPin") := {
       val pkgJson = IO.read(baseDirectory.value / "website" / "package.json")
       val obj     = pkgJson.fromJson[Json.Obj].fold(err => sys.error(s"bad package.json: $err"), identity)


### PR DESCRIPTION
Moves new sites onto **Docusaurus 3.10.2**. Until now `installWebsite` scaffolded from `0.0.1-alpha.14`, published July 2023, producing a Docusaurus 2.1.0 site on React 17.

That staleness was not cosmetic. Security bots kept moving `@docusaurus/core` in downstream repositories without its peers, and the resulting trees stopped resolving — the failure #741 spent a PR untangling here.

[create-zio-website v0.1.0](https://github.com/zio/create-zio-website/releases/tag/v0.1.0) carries the matching peers (`@mdx-js/react ^3`, React 19, `prism-react-renderer ^2`, `clsx ^2`), the config changes Docusaurus 3 requires, and `markdown.format: 'detect'` so existing mdoc output still parses as CommonMark rather than MDX.

## The scripted expectation flips

#752 made the webpack 5.75.0 override conditional on the scaffolded Docusaurus major. A 2.x scaffold needed the pin; a 3.x scaffold must **not** have it, since Docusaurus 3 depends on `webpack ^5.95.0` and pinning 5.75.0 is unsatisfiable.

`checkWebpackPin` already keys off the scaffolded version, so it needed no logic change — only its comment updated. This is the first time that conditional runs against a real Docusaurus 3 scaffold.

## Verification

Against the **published** package, not a local copy:

```
$ sbt "zio-sbt-website/scripted zio-sbt-website/installWebsite"
+ zio-sbt-website/installWebsite
[success] Total time: 173 s
```

That run scaffolds through `npx @zio.dev/create-zio-website@0.1.0` and installs, so a wrong conditional would surface as ERESOLVE rather than passing quietly.

Published tarball verified independently:

| | |
|---|---|
| `@docusaurus/core` | 3.10.2 |
| `@mdx-js/react` | ^3.0.0 |
| `react`, `react-dom` | ^19.0.0 |
| `prism-react-renderer` | ^2.3.0 |
| `clsx` | ^2.0.0 |

## Downstream impact

Checked before the template shipped: 33 repos enable `WebsitePlugin`, but only **15 run `buildWebsite` in CI**. All 15 build against the new template — including `zio/interop-cats`, which regressed on MDX 3 (`FS2 <-> ZStream` parsed as a JSX tag) until `format: 'detect'` was added upstream.

Repos that commit their own `website/` directory, this one included, are unaffected — `installWebsite` skips when a scaffold is already present.