### PR TITLE
Mint a GitHub App token for auto-merge on workflow-touching PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -14,7 +14,6 @@ env: {}
 permissions:
   contents: write
   pull-requests: write
-  actions: write
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.run_id || github.ref }}
   cancel-in-progress: true
@@ -25,11 +24,18 @@ jobs:
     continue-on-error: false
     if: ${{ (((github.event_name == 'workflow_dispatch') || (github.event.pull_request.user.login == 'dependabot[bot]')) || (github.event.pull_request.user.login == 'renovate[bot]')) || (github.event.pull_request.user.login == 'zio-scala-steward[bot]') }}
     steps:
+    - name: Generate Token
+      id: generate-token
+      uses: zio/generate-github-app-token@v1.0.0
+      if: ${{ secrets.APP_ID != '' }}
+      with:
+        app_id: ${{ secrets.APP_ID }}
+        app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
     - name: Enable auto-merge for bot PR
       if: ${{ github.event_name == 'pull_request_target' }}
       run: gh pr merge --auto --squash ${{ github.event.number }}
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN }}
         GH_REPO: ${{ github.repository }}
     - name: Backfill auto-merge for existing bot PRs
       if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -44,5 +50,5 @@ jobs:
           xargs -I{} gh pr merge --auto --squash {}
         done
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN }}
         GH_REPO: ${{ github.repository }}

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ _ZIO SBT_ contains multiple sbt plugins that are useful for ZIO projects. It pro
 Add the following lines to your `project/plugins.sbt` file:
 
 ```scala
-addSbtPlugin("dev.zio" % "zio-sbt-ecosystem" % "0.7.1")
-addSbtPlugin("dev.zio" % "zio-sbt-ci"        % "0.7.1")
-addSbtPlugin("dev.zio" % "zio-sbt-website"   % "0.7.1")
+addSbtPlugin("dev.zio" % "zio-sbt-ecosystem" % "0.7.2")
+addSbtPlugin("dev.zio" % "zio-sbt-ci"        % "0.7.2")
+addSbtPlugin("dev.zio" % "zio-sbt-website"   % "0.7.2")
 ```
 
 Then you can enable them by using the following code in your `build.sbt` file:
@@ -116,7 +116,7 @@ ZIO SBT CI plugin generates a default GitHub workflow that includes common CI ta
 To use ZIO SBT CI plugin, add the following lines to your `plugins.sbt` file:
 
 ```scala
-addSbtPlugin("dev.zio" % "zio-sbt-ci" % "0.7.1")
+addSbtPlugin("dev.zio" % "zio-sbt-ci" % "0.7.2")
 
 resolvers ++= Resolver.sonatypeOssRepos("public")
 ```
@@ -181,6 +181,10 @@ The default value mirrors the bots used by the `zio/zio` repository: `Seq(Depend
 > **Note:**
 >
 > For `gh pr merge --auto` to actually merge a PR (rather than just queue it), the target repository needs "Allow auto-merge" enabled under **Settings → General**, and branch protection with required status checks configured on the target branch.
+
+> **Note:**
+>
+> `GITHUB_TOKEN` can never be granted the "workflows" scope needed to auto-merge a bot PR that touches `.github/workflows/**`, so `auto-merge.yml` mints a GitHub App token for that case instead, falling back to `GITHUB_TOKEN` when no app is configured (which still auto-merges ordinary, non-workflow-touching PRs fine). This needs the same `APP_ID`/`APP_PRIVATE_KEY` secrets as `update-readme`, and the [ZIO Assistant](https://github.com/apps/zio-assistant) app installation must additionally have the **Workflows** repository permission granted and accepted — without it, workflow-touching PRs still fail to auto-merge and need a manual merge.
 
 ### Keeping the Workflow in Sync
 
@@ -395,7 +399,7 @@ ZIO SBT Source is a Scala 2.13 + Scala 3 cross-compiled library that provides ut
 Add the following line to your `libraryDependencies` in `build.sbt`:
 
 ```scala
-libraryDependencies += "dev.zio" %% "zio-sbt-source" % "0.7.1"
+libraryDependencies += "dev.zio" %% "zio-sbt-source" % "0.7.2"
 ```
 
 ### Features

--- a/docs/index.md
+++ b/docs/index.md
@@ -181,6 +181,10 @@ The default value mirrors the bots used by the `zio/zio` repository: `Seq(Depend
 >
 > For `gh pr merge --auto` to actually merge a PR (rather than just queue it), the target repository needs "Allow auto-merge" enabled under **Settings → General**, and branch protection with required status checks configured on the target branch.
 
+> **Note:**
+>
+> `GITHUB_TOKEN` can never be granted the "workflows" scope needed to auto-merge a bot PR that touches `.github/workflows/**`, so `auto-merge.yml` mints a GitHub App token for that case instead, falling back to `GITHUB_TOKEN` when no app is configured (which still auto-merges ordinary, non-workflow-touching PRs fine). This needs the same `APP_ID`/`APP_PRIVATE_KEY` secrets as `update-readme`, and the [ZIO Assistant](https://github.com/apps/zio-assistant) app installation must additionally have the **Workflows** repository permission granted and accepted — without it, workflow-touching PRs still fail to auto-merge and need a manual merge.
+
 ### Keeping the Workflow in Sync
 
 The generated files are meant to be committed and never edited by hand. To stop them drifting from the build, run the check in CI — the default `lint` job already does:

--- a/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
+++ b/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
@@ -738,6 +738,20 @@ object ZioSbtCiPlugin extends AutoPlugin {
     "GH_REPO"  -> "${{ github.repository }}"
   )
 
+  // GITHUB_TOKEN can never be granted the "workflows" scope GitHub's `enablePullRequestAutoMerge`
+  // mutation needs for a PR that touches .github/workflows/** - no `permissions:` grant fixes
+  // that, `actions: write` included, despite the error message asking for a "workflows"
+  // permission that isn't a valid permissions key at all (see #744). A GitHub App token can hold
+  // that scope, so the "Generate Token" step below mints one and this falls back to GITHUB_TOKEN
+  // when no app is configured: `steps.generate-token.outputs.token` is empty both when that step
+  // is skipped (no APP_ID secret) and when it fails, so `||` reaches the fallback either way.
+  // GITHUB_TOKEN alone still auto-merges ordinary, non-workflow-touching dependency PRs fine -
+  // only PRs that touch workflow files need the app's scope.
+  private val mergeTokenEnv: Map[String, String] = Map(
+    "GH_TOKEN" -> "${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN }}",
+    "GH_REPO"  -> "${{ github.repository }}"
+  )
+
   lazy val autoApproveWorkflow: Def.Initialize[Workflow] = Def.setting {
     val bots = ciDependencyUpdateBots.value.map(_.login)
 
@@ -775,11 +789,10 @@ object ZioSbtCiPlugin extends AutoPlugin {
     Workflow(
       name = "Auto-merge bot dependency PRs",
       triggers = dependencyBotPRTriggers,
-      // "actions: write" is required for `gh pr merge --auto` to succeed on PRs that touch
-      // .github/workflows/**, per https://github.com/cli/cli/issues/11493 — GitHub's
-      // enablePullRequestAutoMerge mutation otherwise rejects with a "workflows permission"
-      // error, even though "workflows" isn't a valid permissions key at all.
-      permissions = Map("contents" -> "write", "pull-requests" -> "write", "actions" -> "write"),
+      // `contents`/`pull-requests: write` are for the GITHUB_TOKEN fallback path (see
+      // `mergeTokenEnv`); the app-token path doesn't need this block at all, the app's own
+      // installation permissions govern what its token can do.
+      permissions = Map("contents" -> "write", "pull-requests" -> "write"),
       jobs = Seq(
         Job(
           id = "auto-merge",
@@ -787,16 +800,29 @@ object ZioSbtCiPlugin extends AutoPlugin {
           condition = Some(dependencyBotPRCondition(bots)),
           steps = Seq(
             Step.SingleStep(
+              name = "Generate Token",
+              id = Some("generate-token"),
+              // Skipped (rather than left to fail on empty secrets) on repos that never
+              // configured APP_ID/APP_PRIVATE_KEY, so no action run is wasted on the doomed API
+              // calls that would otherwise make.
+              condition = Some(Condition.Expression("secrets.APP_ID != ''")),
+              uses = Some(ActionRef(V("zio/generate-github-app-token"))),
+              parameters = Map(
+                "app_id"          -> Json.Str("${{ secrets.APP_ID }}"),
+                "app_private_key" -> Json.Str("${{ secrets.APP_PRIVATE_KEY }}")
+              )
+            ),
+            Step.SingleStep(
               name = "Enable auto-merge for bot PR",
               condition = Some(Condition.Expression("github.event_name == 'pull_request_target'")),
               run = Some("gh pr merge --auto --squash ${{ github.event.number }}"),
-              env = botTokenEnv
+              env = mergeTokenEnv
             ),
             Step.SingleStep(
               name = "Backfill auto-merge for existing bot PRs",
               condition = Some(Condition.Expression("github.event_name == 'workflow_dispatch'")),
               run = Some(backfillBotPRsScript(bots, "gh pr merge --auto --squash")),
-              env = botTokenEnv
+              env = mergeTokenEnv
             )
           )
         )

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/defaults-sbt2/expected/auto-merge.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/defaults-sbt2/expected/auto-merge.yml
@@ -14,7 +14,6 @@ env: {}
 permissions:
   contents: write
   pull-requests: write
-  actions: write
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.run_id || github.ref }}
   cancel-in-progress: true
@@ -25,11 +24,18 @@ jobs:
     continue-on-error: false
     if: ${{ (((github.event_name == 'workflow_dispatch') || (github.event.pull_request.user.login == 'dependabot[bot]')) || (github.event.pull_request.user.login == 'renovate[bot]')) || (github.event.pull_request.user.login == 'zio-scala-steward[bot]') }}
     steps:
+    - name: Generate Token
+      id: generate-token
+      uses: zio/generate-github-app-token@v1.0.0
+      if: ${{ secrets.APP_ID != '' }}
+      with:
+        app_id: ${{ secrets.APP_ID }}
+        app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
     - name: Enable auto-merge for bot PR
       if: ${{ github.event_name == 'pull_request_target' }}
       run: gh pr merge --auto --squash ${{ github.event.number }}
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN }}
         GH_REPO: ${{ github.repository }}
     - name: Backfill auto-merge for existing bot PRs
       if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -44,5 +50,5 @@ jobs:
           xargs -I{} gh pr merge --auto --squash {}
         done
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN }}
         GH_REPO: ${{ github.repository }}

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/defaults/expected/auto-merge.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/defaults/expected/auto-merge.yml
@@ -14,7 +14,6 @@ env: {}
 permissions:
   contents: write
   pull-requests: write
-  actions: write
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.run_id || github.ref }}
   cancel-in-progress: true
@@ -25,11 +24,18 @@ jobs:
     continue-on-error: false
     if: ${{ (((github.event_name == 'workflow_dispatch') || (github.event.pull_request.user.login == 'dependabot[bot]')) || (github.event.pull_request.user.login == 'renovate[bot]')) || (github.event.pull_request.user.login == 'zio-scala-steward[bot]') }}
     steps:
+    - name: Generate Token
+      id: generate-token
+      uses: zio/generate-github-app-token@v1.0.0
+      if: ${{ secrets.APP_ID != '' }}
+      with:
+        app_id: ${{ secrets.APP_ID }}
+        app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
     - name: Enable auto-merge for bot PR
       if: ${{ github.event_name == 'pull_request_target' }}
       run: gh pr merge --auto --squash ${{ github.event.number }}
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN }}
         GH_REPO: ${{ github.repository }}
     - name: Backfill auto-merge for existing bot PRs
       if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -44,5 +50,5 @@ jobs:
           xargs -I{} gh pr merge --auto --squash {}
         done
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN }}
         GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary

Fixes #744.

- `GITHUB_TOKEN` can never be granted the "workflows" scope GitHub's `enablePullRequestAutoMerge` mutation needs to merge a bot PR that touches `.github/workflows/**`. The previous `actions: write` workaround in `autoMergeWorkflow` did not actually satisfy that check — confirmed by the issue's own evidence — despite the misleading error message asking for a "workflows" permission that isn't a valid `permissions:` key at all.
- `auto-merge.yml` now mints a GitHub App token the same way `update-readme` already does (the `Generate Token` step, using the `zio/generate-github-app-token` action and the existing `APP_ID`/`APP_PRIVATE_KEY` secrets), and falls back to `GITHUB_TOKEN` when no app is configured or the step is skipped: `GH_TOKEN` is set to `${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN }}`. So ordinary, non-workflow-touching dependency PRs still auto-merge fine on repos that never set the app up — only workflow-touching PRs there still need a manual merge, per the issue's own suggested "degrade sensibly" requirement.
- The `Generate Token` step is conditioned on `secrets.APP_ID != ''`, so it's skipped (not left to fail) on repos without the app configured, rather than spending an action run on doomed API calls.
- `docs/index.md` (and the regenerated `README.md`) now note that the ZIO Assistant app installation needs the **Workflows** repository permission granted for this to work, per the issue's first open question.
- Re-recorded the `defaults`/`defaults-sbt2` scripted fixtures' `expected/auto-merge.yml` goldens to match the new generated output.
- This repo's own `.github/workflows/auto-merge.yml` was regenerated via `sbt ciGenerateGithubWorkflow` and is included in the diff.

## Test plan
- [x] `sbt ++2.12.21 zio-sbt-ci/compile` — passes
- [x] `sbt ciCheckGithubWorkflow` — no drift
- [x] `zio-sbt-ci/defaults` scripted fixture (sbt 1.x) — passes, golden re-recorded
- [x] `zio-sbt-ci/defaults-sbt2` scripted fixture (sbt 2.x, real sbt 2.0.7 process) — passes, golden re-recorded