### PR TITLE
feat(ci): mint a GitHub App token for notify-docs-release instead of PAT_TOKEN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,6 +263,13 @@ jobs:
       uses: actions/checkout@v7.0.1
       with:
         fetch-depth: '0'
+    - name: Generate Token
+      id: generate-token
+      uses: zio/generate-github-app-token@v1.0.0
+      if: ${{ secrets.APP_ID != '' }}
+      with:
+        app_id: ${{ secrets.APP_ID }}
+        app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
     - name: notify the main repo about the new release of docs package
       run: |
         PACKAGE_NAME=$(cat docs/package.json | grep '"name"' | awk -F'"' '{print $4}')
@@ -270,7 +277,7 @@ jobs:
         curl -L \
           -X POST \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: token ${{ secrets.PAT_TOKEN }}"\
+          -H "Authorization: token $NOTIFY_TOKEN"\
             https://api.github.com/repos/zio/zio/dispatches \
             -d '{
                   "event_type":"update-docs",
@@ -279,3 +286,5 @@ jobs:
                     "package_version": "'"${PACKAGE_VERSION}"'"
                   }
                 }'
+      env:
+        NOTIFY_TOKEN: ${{ steps.generate-token.outputs.token || secrets.PAT_TOKEN }}

--- a/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
+++ b/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
@@ -610,14 +610,30 @@ object ZioSbtCiPlugin extends AutoPlugin {
         condition = releaseCondition,
         steps = Seq(
           checkout,
+          // Unlike the auto-merge app-token fallback, this has no GITHUB_TOKEN path to fall back
+          // to: the dispatch below targets zio/zio, a different repository, and GITHUB_TOKEN is
+          // scoped to only the repository the workflow is running in. A minted app token works
+          // only if that app is installed on zio/zio too; PAT_TOKEN remains the fallback for repos
+          // relying on it (or where the app lacks that installation).
+          SingleStep(
+            name = "Generate Token",
+            id = Some("generate-token"),
+            condition = Some(Condition.Expression("secrets.APP_ID != ''")),
+            uses = Some(ActionRef(V("zio/generate-github-app-token"))),
+            parameters = Map(
+              "app_id"          -> Json.Str("${{ secrets.APP_ID }}"),
+              "app_private_key" -> Json.Str("${{ secrets.APP_PRIVATE_KEY }}")
+            )
+          ),
           SingleStep(
             name = "notify the main repo about the new release of docs package",
+            env = Map("NOTIFY_TOKEN" -> "${{ steps.generate-token.outputs.token || secrets.PAT_TOKEN }}"),
             run = Some("""|PACKAGE_NAME=$(cat docs/package.json | grep '"name"' | awk -F'"' '{print $4}')
                           |PACKAGE_VERSION=$(npm view $PACKAGE_NAME version)
                           |curl -L \
                           |  -X POST \
                           |  -H "Accept: application/vnd.github+json" \
-                          |  -H "Authorization: token ${{ secrets.PAT_TOKEN }}"\
+                          |  -H "Authorization: token $NOTIFY_TOKEN"\
                           |    https://api.github.com/repos/zio/zio/dispatches \
                           |    -d '{
                           |          "event_type":"update-docs",

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/bothPlugins/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/bothPlugins/expected/ci.yml
@@ -259,6 +259,13 @@ jobs:
       uses: actions/checkout@v7.0.1
       with:
         fetch-depth: '0'
+    - name: Generate Token
+      id: generate-token
+      uses: zio/generate-github-app-token@v1.0.0
+      if: ${{ secrets.APP_ID != '' }}
+      with:
+        app_id: ${{ secrets.APP_ID }}
+        app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
     - name: notify the main repo about the new release of docs package
       run: |
         PACKAGE_NAME=$(cat docs/package.json | grep '"name"' | awk -F'"' '{print $4}')
@@ -266,7 +273,7 @@ jobs:
         curl -L \
           -X POST \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: token ${{ secrets.PAT_TOKEN }}"\
+          -H "Authorization: token $NOTIFY_TOKEN"\
             https://api.github.com/repos/zio/zio/dispatches \
             -d '{
                   "event_type":"update-docs",
@@ -275,3 +282,5 @@ jobs:
                     "package_version": "'"${PACKAGE_VERSION}"'"
                   }
                 }'
+      env:
+        NOTIFY_TOKEN: ${{ steps.generate-token.outputs.token || secrets.PAT_TOKEN }}

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/concurrency/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/concurrency/expected/ci.yml
@@ -253,6 +253,13 @@ jobs:
       uses: actions/checkout@v7.0.1
       with:
         fetch-depth: '0'
+    - name: Generate Token
+      id: generate-token
+      uses: zio/generate-github-app-token@v1.0.0
+      if: ${{ secrets.APP_ID != '' }}
+      with:
+        app_id: ${{ secrets.APP_ID }}
+        app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
     - name: notify the main repo about the new release of docs package
       run: |
         PACKAGE_NAME=$(cat docs/package.json | grep '"name"' | awk -F'"' '{print $4}')
@@ -260,7 +267,7 @@ jobs:
         curl -L \
           -X POST \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: token ${{ secrets.PAT_TOKEN }}"\
+          -H "Authorization: token $NOTIFY_TOKEN"\
             https://api.github.com/repos/zio/zio/dispatches \
             -d '{
                   "event_type":"update-docs",
@@ -269,3 +276,5 @@ jobs:
                     "package_version": "'"${PACKAGE_VERSION}"'"
                   }
                 }'
+      env:
+        NOTIFY_TOKEN: ${{ steps.generate-token.outputs.token || secrets.PAT_TOKEN }}

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/customJobs/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/customJobs/expected/ci.yml
@@ -271,6 +271,13 @@ jobs:
       uses: actions/checkout@v7.0.1
       with:
         fetch-depth: '0'
+    - name: Generate Token
+      id: generate-token
+      uses: zio/generate-github-app-token@v1.0.0
+      if: ${{ secrets.APP_ID != '' }}
+      with:
+        app_id: ${{ secrets.APP_ID }}
+        app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
     - name: notify the main repo about the new release of docs package
       run: |
         PACKAGE_NAME=$(cat docs/package.json | grep '"name"' | awk -F'"' '{print $4}')
@@ -278,7 +285,7 @@ jobs:
         curl -L \
           -X POST \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: token ${{ secrets.PAT_TOKEN }}"\
+          -H "Authorization: token $NOTIFY_TOKEN"\
             https://api.github.com/repos/zio/zio/dispatches \
             -d '{
                   "event_type":"update-docs",
@@ -287,3 +294,5 @@ jobs:
                     "package_version": "'"${PACKAGE_VERSION}"'"
                   }
                 }'
+      env:
+        NOTIFY_TOKEN: ${{ steps.generate-token.outputs.token || secrets.PAT_TOKEN }}

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/defaults-sbt2/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/defaults-sbt2/expected/ci.yml
@@ -259,6 +259,13 @@ jobs:
       uses: actions/checkout@v7.0.1
       with:
         fetch-depth: '0'
+    - name: Generate Token
+      id: generate-token
+      uses: zio/generate-github-app-token@v1.0.0
+      if: ${{ secrets.APP_ID != '' }}
+      with:
+        app_id: ${{ secrets.APP_ID }}
+        app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
     - name: notify the main repo about the new release of docs package
       run: |
         PACKAGE_NAME=$(cat docs/package.json | grep '"name"' | awk -F'"' '{print $4}')
@@ -266,7 +273,7 @@ jobs:
         curl -L \
           -X POST \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: token ${{ secrets.PAT_TOKEN }}"\
+          -H "Authorization: token $NOTIFY_TOKEN"\
             https://api.github.com/repos/zio/zio/dispatches \
             -d '{
                   "event_type":"update-docs",
@@ -275,3 +282,5 @@ jobs:
                     "package_version": "'"${PACKAGE_VERSION}"'"
                   }
                 }'
+      env:
+        NOTIFY_TOKEN: ${{ steps.generate-token.outputs.token || secrets.PAT_TOKEN }}

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/defaults/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/defaults/expected/ci.yml
@@ -259,6 +259,13 @@ jobs:
       uses: actions/checkout@v7.0.1
       with:
         fetch-depth: '0'
+    - name: Generate Token
+      id: generate-token
+      uses: zio/generate-github-app-token@v1.0.0
+      if: ${{ secrets.APP_ID != '' }}
+      with:
+        app_id: ${{ secrets.APP_ID }}
+        app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
     - name: notify the main repo about the new release of docs package
       run: |
         PACKAGE_NAME=$(cat docs/package.json | grep '"name"' | awk -F'"' '{print $4}')
@@ -266,7 +273,7 @@ jobs:
         curl -L \
           -X POST \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: token ${{ secrets.PAT_TOKEN }}"\
+          -H "Authorization: token $NOTIFY_TOKEN"\
             https://api.github.com/repos/zio/zio/dispatches \
             -d '{
                   "event_type":"update-docs",
@@ -275,3 +282,5 @@ jobs:
                     "package_version": "'"${PACKAGE_VERSION}"'"
                   }
                 }'
+      env:
+        NOTIFY_TOKEN: ${{ steps.generate-token.outputs.token || secrets.PAT_TOKEN }}

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/flattenTests/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/flattenTests/expected/ci.yml
@@ -263,6 +263,13 @@ jobs:
       uses: actions/checkout@v7.0.1
       with:
         fetch-depth: '0'
+    - name: Generate Token
+      id: generate-token
+      uses: zio/generate-github-app-token@v1.0.0
+      if: ${{ secrets.APP_ID != '' }}
+      with:
+        app_id: ${{ secrets.APP_ID }}
+        app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
     - name: notify the main repo about the new release of docs package
       run: |
         PACKAGE_NAME=$(cat docs/package.json | grep '"name"' | awk -F'"' '{print $4}')
@@ -270,7 +277,7 @@ jobs:
         curl -L \
           -X POST \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: token ${{ secrets.PAT_TOKEN }}"\
+          -H "Authorization: token $NOTIFY_TOKEN"\
             https://api.github.com/repos/zio/zio/dispatches \
             -d '{
                   "event_type":"update-docs",
@@ -279,3 +286,5 @@ jobs:
                     "package_version": "'"${PACKAGE_VERSION}"'"
                   }
                 }'
+      env:
+        NOTIFY_TOKEN: ${{ steps.generate-token.outputs.token || secrets.PAT_TOKEN }}

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/groupTests/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/groupTests/expected/ci.yml
@@ -268,6 +268,13 @@ jobs:
       uses: actions/checkout@v7.0.1
       with:
         fetch-depth: '0'
+    - name: Generate Token
+      id: generate-token
+      uses: zio/generate-github-app-token@v1.0.0
+      if: ${{ secrets.APP_ID != '' }}
+      with:
+        app_id: ${{ secrets.APP_ID }}
+        app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
     - name: notify the main repo about the new release of docs package
       run: |
         PACKAGE_NAME=$(cat docs/package.json | grep '"name"' | awk -F'"' '{print $4}')
@@ -275,7 +282,7 @@ jobs:
         curl -L \
           -X POST \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: token ${{ secrets.PAT_TOKEN }}"\
+          -H "Authorization: token $NOTIFY_TOKEN"\
             https://api.github.com/repos/zio/zio/dispatches \
             -d '{
                   "event_type":"update-docs",
@@ -284,3 +291,5 @@ jobs:
                     "package_version": "'"${PACKAGE_VERSION}"'"
                   }
                 }'
+      env:
+        NOTIFY_TOKEN: ${{ steps.generate-token.outputs.token || secrets.PAT_TOKEN }}

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/mappedJobs/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/mappedJobs/expected/ci.yml
@@ -285,6 +285,13 @@ jobs:
       uses: actions/checkout@v7.0.1
       with:
         fetch-depth: '0'
+    - name: Generate Token
+      id: generate-token
+      uses: zio/generate-github-app-token@v1.0.0
+      if: ${{ secrets.APP_ID != '' }}
+      with:
+        app_id: ${{ secrets.APP_ID }}
+        app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
     - name: notify the main repo about the new release of docs package
       run: |
         PACKAGE_NAME=$(cat docs/package.json | grep '"name"' | awk -F'"' '{print $4}')
@@ -292,7 +299,7 @@ jobs:
         curl -L \
           -X POST \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: token ${{ secrets.PAT_TOKEN }}"\
+          -H "Authorization: token $NOTIFY_TOKEN"\
             https://api.github.com/repos/zio/zio/dispatches \
             -d '{
                   "event_type":"update-docs",
@@ -301,3 +308,5 @@ jobs:
                     "package_version": "'"${PACKAGE_VERSION}"'"
                   }
                 }'
+      env:
+        NOTIFY_TOKEN: ${{ steps.generate-token.outputs.token || secrets.PAT_TOKEN }}

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/services/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/services/expected/ci.yml
@@ -265,6 +265,13 @@ jobs:
       uses: actions/checkout@v7.0.1
       with:
         fetch-depth: '0'
+    - name: Generate Token
+      id: generate-token
+      uses: zio/generate-github-app-token@v1.0.0
+      if: ${{ secrets.APP_ID != '' }}
+      with:
+        app_id: ${{ secrets.APP_ID }}
+        app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
     - name: notify the main repo about the new release of docs package
       run: |
         PACKAGE_NAME=$(cat docs/package.json | grep '"name"' | awk -F'"' '{print $4}')
@@ -272,7 +279,7 @@ jobs:
         curl -L \
           -X POST \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: token ${{ secrets.PAT_TOKEN }}"\
+          -H "Authorization: token $NOTIFY_TOKEN"\
             https://api.github.com/repos/zio/zio/dispatches \
             -d '{
                   "event_type":"update-docs",
@@ -281,3 +288,5 @@ jobs:
                     "package_version": "'"${PACKAGE_VERSION}"'"
                   }
                 }'
+      env:
+        NOTIFY_TOKEN: ${{ steps.generate-token.outputs.token || secrets.PAT_TOKEN }}

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/settingsOverrides/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/settingsOverrides/expected/ci.yml
@@ -262,6 +262,13 @@ jobs:
       uses: actions/checkout@v7.0.1
       with:
         fetch-depth: '0'
+    - name: Generate Token
+      id: generate-token
+      uses: zio/generate-github-app-token@v1.0.0
+      if: ${{ secrets.APP_ID != '' }}
+      with:
+        app_id: ${{ secrets.APP_ID }}
+        app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
     - name: notify the main repo about the new release of docs package
       run: |
         PACKAGE_NAME=$(cat docs/package.json | grep '"name"' | awk -F'"' '{print $4}')
@@ -269,7 +276,7 @@ jobs:
         curl -L \
           -X POST \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: token ${{ secrets.PAT_TOKEN }}"\
+          -H "Authorization: token $NOTIFY_TOKEN"\
             https://api.github.com/repos/zio/zio/dispatches \
             -d '{
                   "event_type":"update-docs",
@@ -278,3 +285,5 @@ jobs:
                     "package_version": "'"${PACKAGE_VERSION}"'"
                   }
                 }'
+      env:
+        NOTIFY_TOKEN: ${{ steps.generate-token.outputs.token || secrets.PAT_TOKEN }}

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowEnv/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowEnv/expected/ci.yml
@@ -259,6 +259,13 @@ jobs:
       uses: actions/checkout@v7.0.1
       with:
         fetch-depth: '0'
+    - name: Generate Token
+      id: generate-token
+      uses: zio/generate-github-app-token@v1.0.0
+      if: ${{ secrets.APP_ID != '' }}
+      with:
+        app_id: ${{ secrets.APP_ID }}
+        app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
     - name: notify the main repo about the new release of docs package
       run: |
         PACKAGE_NAME=$(cat docs/package.json | grep '"name"' | awk -F'"' '{print $4}')
@@ -266,7 +273,7 @@ jobs:
         curl -L \
           -X POST \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: token ${{ secrets.PAT_TOKEN }}"\
+          -H "Authorization: token $NOTIFY_TOKEN"\
             https://api.github.com/repos/zio/zio/dispatches \
             -d '{
                   "event_type":"update-docs",
@@ -275,3 +282,5 @@ jobs:
                     "package_version": "'"${PACKAGE_VERSION}"'"
                   }
                 }'
+      env:
+        NOTIFY_TOKEN: ${{ steps.generate-token.outputs.token || secrets.PAT_TOKEN }}

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowTriggers/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowTriggers/expected/ci.yml
@@ -258,6 +258,13 @@ jobs:
       uses: actions/checkout@v7.0.1
       with:
         fetch-depth: '0'
+    - name: Generate Token
+      id: generate-token
+      uses: zio/generate-github-app-token@v1.0.0
+      if: ${{ secrets.APP_ID != '' }}
+      with:
+        app_id: ${{ secrets.APP_ID }}
+        app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
     - name: notify the main repo about the new release of docs package
       run: |
         PACKAGE_NAME=$(cat docs/package.json | grep '"name"' | awk -F'"' '{print $4}')
@@ -265,7 +272,7 @@ jobs:
         curl -L \
           -X POST \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: token ${{ secrets.PAT_TOKEN }}"\
+          -H "Authorization: token $NOTIFY_TOKEN"\
             https://api.github.com/repos/zio/zio/dispatches \
             -d '{
                   "event_type":"update-docs",
@@ -274,3 +281,5 @@ jobs:
                     "package_version": "'"${PACKAGE_VERSION}"'"
                   }
                 }'
+      env:
+        NOTIFY_TOKEN: ${{ steps.generate-token.outputs.token || secrets.PAT_TOKEN }}


### PR DESCRIPTION
## Motivation

`notify-docs-release` pings `zio/zio`'s `repository_dispatch` after a docs publish, using `secrets.PAT_TOKEN` - a static personal access token that has to be manually provisioned per consuming repo before this job can work at all. `zio/zio-cli` hit exactly this: after adopting `zio-sbt-ci`, its docs pipeline is otherwise fully working (OIDC npm trusted publishing, the `update-readme` fix from #757/#758), but this one job is still blocked on a `PAT_TOKEN` secret nobody's set up for it.

## Change

Same pattern already established for `auto-merge.yml`'s own token problem: mint a short-lived GitHub App installation token via the existing `zio/generate-github-app-token` action and `APP_ID`/`APP_PRIVATE_KEY` secrets, gated on `secrets.APP_ID != ''` so repos without the app configured skip cleanly. `PAT_TOKEN` stays as the fallback (`steps.generate-token.outputs.token || secrets.PAT_TOKEN`), so nothing already relying on it breaks.

One real difference from the `auto-merge.yml` case worth calling out: there's no `GITHUB_TOKEN` fallback here, because the dispatch targets `zio/zio` - a *different* repository - and `GITHUB_TOKEN` is scoped only to the repo the workflow runs in. The minted app token only helps if that app is actually installed on `zio/zio` too; if not, this fails the same way a missing `PAT_TOKEN` does today, no worse off.

## Test plan

- [x] `sbt ciGenerateGithubWorkflow` produces exactly the expected diff in this repo's own `ci.yml` (Generate Token step + env-based Authorization header)
- [x] All 11 sbt-1.x `zio-sbt-ci` scripted tests pass with their golden files updated to match
- [ ] The new `defaults-sbt2` fixture couldn't be re-verified in this sandbox - same pre-existing dynver-timestamp/local-publish environment limitation #760 already flagged as unresolved there. Its golden file was patched identically to the other 11 and to the real dogfooded diff, but hasn't run green locally.
- [x] `sbt fmt lint` clean
- [ ] Confirm in CI that `defaults-sbt2` still passes