### PR TITLE
Document zioVersion and recommend overriding it explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,21 @@ There are also some other settings that are useful for configuring the projects:
 - `enableZIO`- a set of ZIO related settings such as enabling zio streams and ZIO test framework.
 - `jsSettings`, `nativeSettings`- common platform specific settings for Scala.js and Scala Native.
 
+`enableZIO` adds ZIO as a dependency using the `zioVersion` setting, which the plugin gives a
+default value to. Always override it explicitly in your own `build.sbt`:
+
+```scala
+ThisBuild / zioVersion := "2.1.22"
+```
+
+:::note
+Don't rely on `zioVersion`'s default. It's baked into whichever version of zio-sbt-ecosystem you
+depend on, so upgrading the plugin—including via an automated dependency-update PR—can silently
+change your project's own ZIO version along with it. Setting `zioVersion` explicitly keeps that a
+deliberate decision you make, not a side effect of a plugin bump. Every ZIO ecosystem project
+(zio-logging, zio-kafka, zio-cache, and others) already follows this practice.
+:::
+
 It also provides some helper methods that are useful for configuring a compiler option for a specific Scala version:
 
 - `optionsOn`

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,6 +60,21 @@ There are also some other settings that are useful for configuring the projects:
 - `enableZIO`- a set of ZIO related settings such as enabling zio streams and ZIO test framework.
 - `jsSettings`, `nativeSettings`- common platform specific settings for Scala.js and Scala Native.
 
+`enableZIO` adds ZIO as a dependency using the `zioVersion` setting, which the plugin gives a
+default value to. Always override it explicitly in your own `build.sbt`:
+
+```scala
+ThisBuild / zioVersion := "2.1.22"
+```
+
+:::note
+Don't rely on `zioVersion`'s default. It's baked into whichever version of zio-sbt-ecosystem you
+depend on, so upgrading the plugin—including via an automated dependency-update PR—can silently
+change your project's own ZIO version along with it. Setting `zioVersion` explicitly keeps that a
+deliberate decision you make, not a side effect of a plugin bump. Every ZIO ecosystem project
+(zio-logging, zio-kafka, zio-cache, and others) already follows this practice.
+:::
+
 It also provides some helper methods that are useful for configuring a compiler option for a specific Scala version:
 
 - `optionsOn`


### PR DESCRIPTION
## Summary

Addresses part of #410 ("Remove the automatic dependency on zio").

`enableZIO()` adds ZIO via the `zioVersion` setting, which the plugin gives a default value baked into whichever `zio-sbt-ecosystem` release is in use — upgrading the plugin can silently change a consumer's own ZIO dependency along with it, which is what originally broke zio-logging when zio-sbt pulled in ZIO 2.1.1 unannounced (per #410).

In practice, every real downstream consumer I checked already works around this by setting `zioVersion` explicitly:

- zio-logging, zio-redis, zio-kafka, zio-telemetry, zio-query, zio-cache, zio-bson — all seven do

But this convention was never written down anywhere in zio-sbt's own docs — `docs/index.md` mentioned `enableZIO` in a single bullet and never mentioned `zioVersion` at all. This adds that guidance right next to the `enableZIO` bullet, and regenerates `README.md` from it.

This is docs-only, no code/behavior change, so no breakage risk.

## Follow-up

Filed #768 to decide separately whether to also enforce this at the code level (e.g. make `zioVersion` mandatory with no default, or warn when left at the default) now that the documentation gap itself is closed.

## Test plan
- [x] `sbt docs/generateReadme` — regenerated README.md cleanly, diff reviewed