### PR TITLE
fix(ci): stop using secrets in if: conditions, which breaks the whole workflow file

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -24,10 +24,20 @@ jobs:
     continue-on-error: false
     if: ${{ (((github.event_name == 'workflow_dispatch') || (github.event.pull_request.user.login == 'dependabot[bot]')) || (github.event.pull_request.user.login == 'renovate[bot]')) || (github.event.pull_request.user.login == 'zio-scala-steward[bot]') }}
     steps:
+    - name: Check App Token
+      id: check-app-token
+      run: |
+        if [ -n "$APP_ID" ]; then
+          echo "configured=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "configured=false" >> "$GITHUB_OUTPUT"
+        fi
+      env:
+        APP_ID: ${{ secrets.APP_ID }}
     - name: Generate Token
       id: generate-token
       uses: zio/generate-github-app-token@v1.0.0
-      if: ${{ secrets.APP_ID != '' }}
+      if: ${{ steps.check-app-token.outputs.configured == 'true' }}
       with:
         app_id: ${{ secrets.APP_ID }}
         app_private_key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,10 +263,20 @@ jobs:
       uses: actions/checkout@v7.0.1
       with:
         fetch-depth: '0'
+    - name: Check App Token
+      id: check-app-token
+      run: |
+        if [ -n "$APP_ID" ]; then
+          echo "configured=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "configured=false" >> "$GITHUB_OUTPUT"
+        fi
+      env:
+        APP_ID: ${{ secrets.APP_ID }}
     - name: Generate Token
       id: generate-token
       uses: zio/generate-github-app-token@v1.0.0
-      if: ${{ secrets.APP_ID != '' }}
+      if: ${{ steps.check-app-token.outputs.configured == 'true' }}
       with:
         app_id: ${{ secrets.APP_ID }}
         app_private_key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
+++ b/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
@@ -615,10 +615,11 @@ object ZioSbtCiPlugin extends AutoPlugin {
           // scoped to only the repository the workflow is running in. A minted app token works
           // only if that app is installed on zio/zio too; PAT_TOKEN remains the fallback for repos
           // relying on it (or where the app lacks that installation).
+          checkAppTokenStep,
           SingleStep(
             name = "Generate Token",
             id = Some("generate-token"),
-            condition = Some(Condition.Expression("secrets.APP_ID != ''")),
+            condition = Some(appTokenConfigured),
             uses = Some(ActionRef(V("zio/generate-github-app-token"))),
             parameters = Map(
               "app_id"          -> Json.Str("${{ secrets.APP_ID }}"),
@@ -768,6 +769,28 @@ object ZioSbtCiPlugin extends AutoPlugin {
     "GH_REPO"  -> "${{ github.repository }}"
   )
 
+  // GitHub rejects the `secrets` context in any `if:` - job or step - with "Unrecognized
+  // named-value: 'secrets'", failing the *entire* workflow file (every job, every trigger), not
+  // just the step that used it. `secrets` is readable in `env:`/`run:` though, so this step reads
+  // it there and exposes the result as a step output, which `if:` conditions may reference freely.
+  private val checkAppTokenStep: Step.SingleStep =
+    Step.SingleStep(
+      name = "Check App Token",
+      id = Some("check-app-token"),
+      env = Map("APP_ID" -> "${{ secrets.APP_ID }}"),
+      run = Some(
+        """|if [ -n "$APP_ID" ]; then
+           |  echo "configured=true" >> "$GITHUB_OUTPUT"
+           |else
+           |  echo "configured=false" >> "$GITHUB_OUTPUT"
+           |fi
+           |""".stripMargin
+      )
+    )
+
+  private val appTokenConfigured: Condition =
+    Condition.Expression("steps.check-app-token.outputs.configured == 'true'")
+
   lazy val autoApproveWorkflow: Def.Initialize[Workflow] = Def.setting {
     val bots = ciDependencyUpdateBots.value.map(_.login)
 
@@ -815,13 +838,14 @@ object ZioSbtCiPlugin extends AutoPlugin {
           name = "auto-merge",
           condition = Some(dependencyBotPRCondition(bots)),
           steps = Seq(
+            checkAppTokenStep,
             Step.SingleStep(
               name = "Generate Token",
               id = Some("generate-token"),
               // Skipped (rather than left to fail on empty secrets) on repos that never
               // configured APP_ID/APP_PRIVATE_KEY, so no action run is wasted on the doomed API
               // calls that would otherwise make.
-              condition = Some(Condition.Expression("secrets.APP_ID != ''")),
+              condition = Some(appTokenConfigured),
               uses = Some(ActionRef(V("zio/generate-github-app-token"))),
               parameters = Map(
                 "app_id"          -> Json.Str("${{ secrets.APP_ID }}"),

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/bothPlugins/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/bothPlugins/expected/ci.yml
@@ -259,10 +259,20 @@ jobs:
       uses: actions/checkout@v7.0.1
       with:
         fetch-depth: '0'
+    - name: Check App Token
+      id: check-app-token
+      run: |
+        if [ -n "$APP_ID" ]; then
+          echo "configured=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "configured=false" >> "$GITHUB_OUTPUT"
+        fi
+      env:
+        APP_ID: ${{ secrets.APP_ID }}
     - name: Generate Token
       id: generate-token
       uses: zio/generate-github-app-token@v1.0.0
-      if: ${{ secrets.APP_ID != '' }}
+      if: ${{ steps.check-app-token.outputs.configured == 'true' }}
       with:
         app_id: ${{ secrets.APP_ID }}
         app_private_key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/concurrency/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/concurrency/expected/ci.yml
@@ -253,10 +253,20 @@ jobs:
       uses: actions/checkout@v7.0.1
       with:
         fetch-depth: '0'
+    - name: Check App Token
+      id: check-app-token
+      run: |
+        if [ -n "$APP_ID" ]; then
+          echo "configured=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "configured=false" >> "$GITHUB_OUTPUT"
+        fi
+      env:
+        APP_ID: ${{ secrets.APP_ID }}
     - name: Generate Token
       id: generate-token
       uses: zio/generate-github-app-token@v1.0.0
-      if: ${{ secrets.APP_ID != '' }}
+      if: ${{ steps.check-app-token.outputs.configured == 'true' }}
       with:
         app_id: ${{ secrets.APP_ID }}
         app_private_key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/customJobs/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/customJobs/expected/ci.yml
@@ -271,10 +271,20 @@ jobs:
       uses: actions/checkout@v7.0.1
       with:
         fetch-depth: '0'
+    - name: Check App Token
+      id: check-app-token
+      run: |
+        if [ -n "$APP_ID" ]; then
+          echo "configured=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "configured=false" >> "$GITHUB_OUTPUT"
+        fi
+      env:
+        APP_ID: ${{ secrets.APP_ID }}
     - name: Generate Token
       id: generate-token
       uses: zio/generate-github-app-token@v1.0.0
-      if: ${{ secrets.APP_ID != '' }}
+      if: ${{ steps.check-app-token.outputs.configured == 'true' }}
       with:
         app_id: ${{ secrets.APP_ID }}
         app_private_key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/defaults-sbt2/expected/auto-merge.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/defaults-sbt2/expected/auto-merge.yml
@@ -24,10 +24,20 @@ jobs:
     continue-on-error: false
     if: ${{ (((github.event_name == 'workflow_dispatch') || (github.event.pull_request.user.login == 'dependabot[bot]')) || (github.event.pull_request.user.login == 'renovate[bot]')) || (github.event.pull_request.user.login == 'zio-scala-steward[bot]') }}
     steps:
+    - name: Check App Token
+      id: check-app-token
+      run: |
+        if [ -n "$APP_ID" ]; then
+          echo "configured=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "configured=false" >> "$GITHUB_OUTPUT"
+        fi
+      env:
+        APP_ID: ${{ secrets.APP_ID }}
     - name: Generate Token
       id: generate-token
       uses: zio/generate-github-app-token@v1.0.0
-      if: ${{ secrets.APP_ID != '' }}
+      if: ${{ steps.check-app-token.outputs.configured == 'true' }}
       with:
         app_id: ${{ secrets.APP_ID }}
         app_private_key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/defaults-sbt2/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/defaults-sbt2/expected/ci.yml
@@ -259,10 +259,20 @@ jobs:
       uses: actions/checkout@v7.0.1
       with:
         fetch-depth: '0'
+    - name: Check App Token
+      id: check-app-token
+      run: |
+        if [ -n "$APP_ID" ]; then
+          echo "configured=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "configured=false" >> "$GITHUB_OUTPUT"
+        fi
+      env:
+        APP_ID: ${{ secrets.APP_ID }}
     - name: Generate Token
       id: generate-token
       uses: zio/generate-github-app-token@v1.0.0
-      if: ${{ secrets.APP_ID != '' }}
+      if: ${{ steps.check-app-token.outputs.configured == 'true' }}
       with:
         app_id: ${{ secrets.APP_ID }}
         app_private_key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/defaults/expected/auto-merge.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/defaults/expected/auto-merge.yml
@@ -24,10 +24,20 @@ jobs:
     continue-on-error: false
     if: ${{ (((github.event_name == 'workflow_dispatch') || (github.event.pull_request.user.login == 'dependabot[bot]')) || (github.event.pull_request.user.login == 'renovate[bot]')) || (github.event.pull_request.user.login == 'zio-scala-steward[bot]') }}
     steps:
+    - name: Check App Token
+      id: check-app-token
+      run: |
+        if [ -n "$APP_ID" ]; then
+          echo "configured=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "configured=false" >> "$GITHUB_OUTPUT"
+        fi
+      env:
+        APP_ID: ${{ secrets.APP_ID }}
     - name: Generate Token
       id: generate-token
       uses: zio/generate-github-app-token@v1.0.0
-      if: ${{ secrets.APP_ID != '' }}
+      if: ${{ steps.check-app-token.outputs.configured == 'true' }}
       with:
         app_id: ${{ secrets.APP_ID }}
         app_private_key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/defaults/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/defaults/expected/ci.yml
@@ -259,10 +259,20 @@ jobs:
       uses: actions/checkout@v7.0.1
       with:
         fetch-depth: '0'
+    - name: Check App Token
+      id: check-app-token
+      run: |
+        if [ -n "$APP_ID" ]; then
+          echo "configured=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "configured=false" >> "$GITHUB_OUTPUT"
+        fi
+      env:
+        APP_ID: ${{ secrets.APP_ID }}
     - name: Generate Token
       id: generate-token
       uses: zio/generate-github-app-token@v1.0.0
-      if: ${{ secrets.APP_ID != '' }}
+      if: ${{ steps.check-app-token.outputs.configured == 'true' }}
       with:
         app_id: ${{ secrets.APP_ID }}
         app_private_key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/flattenTests/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/flattenTests/expected/ci.yml
@@ -263,10 +263,20 @@ jobs:
       uses: actions/checkout@v7.0.1
       with:
         fetch-depth: '0'
+    - name: Check App Token
+      id: check-app-token
+      run: |
+        if [ -n "$APP_ID" ]; then
+          echo "configured=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "configured=false" >> "$GITHUB_OUTPUT"
+        fi
+      env:
+        APP_ID: ${{ secrets.APP_ID }}
     - name: Generate Token
       id: generate-token
       uses: zio/generate-github-app-token@v1.0.0
-      if: ${{ secrets.APP_ID != '' }}
+      if: ${{ steps.check-app-token.outputs.configured == 'true' }}
       with:
         app_id: ${{ secrets.APP_ID }}
         app_private_key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/groupTests/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/groupTests/expected/ci.yml
@@ -268,10 +268,20 @@ jobs:
       uses: actions/checkout@v7.0.1
       with:
         fetch-depth: '0'
+    - name: Check App Token
+      id: check-app-token
+      run: |
+        if [ -n "$APP_ID" ]; then
+          echo "configured=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "configured=false" >> "$GITHUB_OUTPUT"
+        fi
+      env:
+        APP_ID: ${{ secrets.APP_ID }}
     - name: Generate Token
       id: generate-token
       uses: zio/generate-github-app-token@v1.0.0
-      if: ${{ secrets.APP_ID != '' }}
+      if: ${{ steps.check-app-token.outputs.configured == 'true' }}
       with:
         app_id: ${{ secrets.APP_ID }}
         app_private_key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/mappedJobs/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/mappedJobs/expected/ci.yml
@@ -285,10 +285,20 @@ jobs:
       uses: actions/checkout@v7.0.1
       with:
         fetch-depth: '0'
+    - name: Check App Token
+      id: check-app-token
+      run: |
+        if [ -n "$APP_ID" ]; then
+          echo "configured=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "configured=false" >> "$GITHUB_OUTPUT"
+        fi
+      env:
+        APP_ID: ${{ secrets.APP_ID }}
     - name: Generate Token
       id: generate-token
       uses: zio/generate-github-app-token@v1.0.0
-      if: ${{ secrets.APP_ID != '' }}
+      if: ${{ steps.check-app-token.outputs.configured == 'true' }}
       with:
         app_id: ${{ secrets.APP_ID }}
         app_private_key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/services/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/services/expected/ci.yml
@@ -265,10 +265,20 @@ jobs:
       uses: actions/checkout@v7.0.1
       with:
         fetch-depth: '0'
+    - name: Check App Token
+      id: check-app-token
+      run: |
+        if [ -n "$APP_ID" ]; then
+          echo "configured=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "configured=false" >> "$GITHUB_OUTPUT"
+        fi
+      env:
+        APP_ID: ${{ secrets.APP_ID }}
     - name: Generate Token
       id: generate-token
       uses: zio/generate-github-app-token@v1.0.0
-      if: ${{ secrets.APP_ID != '' }}
+      if: ${{ steps.check-app-token.outputs.configured == 'true' }}
       with:
         app_id: ${{ secrets.APP_ID }}
         app_private_key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/settingsOverrides/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/settingsOverrides/expected/ci.yml
@@ -262,10 +262,20 @@ jobs:
       uses: actions/checkout@v7.0.1
       with:
         fetch-depth: '0'
+    - name: Check App Token
+      id: check-app-token
+      run: |
+        if [ -n "$APP_ID" ]; then
+          echo "configured=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "configured=false" >> "$GITHUB_OUTPUT"
+        fi
+      env:
+        APP_ID: ${{ secrets.APP_ID }}
     - name: Generate Token
       id: generate-token
       uses: zio/generate-github-app-token@v1.0.0
-      if: ${{ secrets.APP_ID != '' }}
+      if: ${{ steps.check-app-token.outputs.configured == 'true' }}
       with:
         app_id: ${{ secrets.APP_ID }}
         app_private_key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowEnv/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowEnv/expected/ci.yml
@@ -259,10 +259,20 @@ jobs:
       uses: actions/checkout@v7.0.1
       with:
         fetch-depth: '0'
+    - name: Check App Token
+      id: check-app-token
+      run: |
+        if [ -n "$APP_ID" ]; then
+          echo "configured=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "configured=false" >> "$GITHUB_OUTPUT"
+        fi
+      env:
+        APP_ID: ${{ secrets.APP_ID }}
     - name: Generate Token
       id: generate-token
       uses: zio/generate-github-app-token@v1.0.0
-      if: ${{ secrets.APP_ID != '' }}
+      if: ${{ steps.check-app-token.outputs.configured == 'true' }}
       with:
         app_id: ${{ secrets.APP_ID }}
         app_private_key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowTriggers/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowTriggers/expected/ci.yml
@@ -258,10 +258,20 @@ jobs:
       uses: actions/checkout@v7.0.1
       with:
         fetch-depth: '0'
+    - name: Check App Token
+      id: check-app-token
+      run: |
+        if [ -n "$APP_ID" ]; then
+          echo "configured=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "configured=false" >> "$GITHUB_OUTPUT"
+        fi
+      env:
+        APP_ID: ${{ secrets.APP_ID }}
     - name: Generate Token
       id: generate-token
       uses: zio/generate-github-app-token@v1.0.0
-      if: ${{ secrets.APP_ID != '' }}
+      if: ${{ steps.check-app-token.outputs.configured == 'true' }}
       with:
         app_id: ${{ secrets.APP_ID }}
         app_private_key: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Problem

GitHub Actions rejects the `secrets` context in any `if:` condition — job-level or step-level — with `Unrecognized named-value: 'secrets'`. When that happens, **the entire workflow file fails to validate**, so no job runs for any trigger of that workflow, not just the offending step.

`ci.yml`'s `notify-docs-release` job (#765/#766) and `auto-merge.yml`'s `Generate Token` step (#762) both gate on:

```yaml
if: ${{ secrets.APP_ID != '' }}
```

This has been silently breaking every run of both workflows on `main` since #766 merged earlier today — including blocking `pull_request` checks (`build`/`lint`/`test`) on every open PR, since GitHub can't schedule jobs from a workflow file it can't validate. Confirmed via `gh api repos/zio/zio-sbt/actions/runs/<id>` showing `conclusion: failure` with 0 jobs and the message *"This run likely failed because of a workflow file issue"*, and directly via GitHub's docs confirming `secrets` is unavailable in `if:` at both job and step scope.

## Fix

`secrets` **is** readable in a step's `env:`/`run:`. So read it there in a small preceding step, and expose the result as a step output — `if:` conditions can reference `steps.*.outputs.*` freely:

```yaml
- name: Check App Token
  id: check-app-token
  run: |
    if [ -n "$APP_ID" ]; then
      echo "configured=true" >> "$GITHUB_OUTPUT"
    else
      echo "configured=false" >> "$GITHUB_OUTPUT"
    fi
  env:
    APP_ID: ${{ secrets.APP_ID }}
- name: Generate Token
  if: ${{ steps.check-app-token.outputs.configured == 'true' }}
  ...
```

Implemented once in `ZioSbtCiPlugin.scala` (`checkAppTokenStep`/`appTokenConfigured`) and reused by both jobs, then regenerated via `sbt ciGenerateGithubWorkflow`.

## Verification

- `sbt zio-sbt-ci/compile` clean, `sbt lint` clean.
- Regenerated `ci.yml`/`auto-merge.yml` diffs match exactly what's described above, nothing else changed.
- This PR itself is the real test: if `build`/`lint`/`test` actually run on it (rather than silently not triggering at all, as happened on #767), that confirms the fix.
