### PR TITLE
docs: clarify where Netlify secrets come from

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ The feature is split across two workflows, decoupled by artifacts rather than tr
 
 Using `workflow_run` instead of triggering directly on `pull_request` means the deploy step only ever runs after CI has actually succeeded, and it runs with read/write access to secrets even for pull requests from forks (where a plain `pull_request` trigger would not have that access).
 
-This requires two repository secrets to be configured on the Netlify site's dashboard: `NETLIFY_AUTH_TOKEN` and `NETLIFY_SITE_ID`. The default value of `ciEnableNetlifyDeployPreview` is `false`, so existing builds see no change until they opt in.
+This requires two GitHub repository secrets: `NETLIFY_AUTH_TOKEN`, a [personal access token](https://docs.netlify.com/api/get-started/#authentication) generated from the Netlify user account that owns the site, and `NETLIFY_SITE_ID`, found under the site's **Site configuration → General → Site details** in the Netlify dashboard. The default value of `ciEnableNetlifyDeployPreview` is `false`, so existing builds see no change until they opt in.
 
 ### Keeping the Workflow in Sync
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -211,7 +211,7 @@ The feature is split across two workflows, decoupled by artifacts rather than tr
 
 Using `workflow_run` instead of triggering directly on `pull_request` means the deploy step only ever runs after CI has actually succeeded, and it runs with read/write access to secrets even for pull requests from forks (where a plain `pull_request` trigger would not have that access).
 
-This requires two repository secrets to be configured on the Netlify site's dashboard: `NETLIFY_AUTH_TOKEN` and `NETLIFY_SITE_ID`. The default value of `ciEnableNetlifyDeployPreview` is `false`, so existing builds see no change until they opt in.
+This requires two GitHub repository secrets: `NETLIFY_AUTH_TOKEN`, a [personal access token](https://docs.netlify.com/api/get-started/#authentication) generated from the Netlify user account that owns the site, and `NETLIFY_SITE_ID`, found under the site's **Site configuration → General → Site details** in the Netlify dashboard. The default value of `ciEnableNetlifyDeployPreview` is `false`, so existing builds see no change until they opt in.
 
 ### Keeping the Workflow in Sync
 


### PR DESCRIPTION
## Summary
- Small doc clarification for the Netlify Deploy Previews section added in #770: `NETLIFY_AUTH_TOKEN` is a personal access token tied to the Netlify *user account*, not something found "on the site's dashboard" like `NETLIFY_SITE_ID` is.
- Doubles as a smoke test for #770: this PR touches `docs/`, so it should trigger the new website-artifact upload in `build` and the `deploy-preview.yml` workflow once CI passes.

## Test plan
- [ ] CI's `build` job uploads `website-artifact` + `pr-metadata`
- [ ] `deploy-preview.yml` fires after CI succeeds and deploys to Netlify
- [ ] A sticky comment with the preview URL appears on this PR