### PR TITLE
fix(ci): stop dependabot from monitoring generated github-actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,12 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
+  # GitHub Actions versions are pinned in zio-sbt-ci's `V.scala` and baked into
+  # `.github/workflows/*.yml` by `sbt ciGenerateGithubWorkflow`. Dependabot's
+  # github-actions ecosystem can only edit the generated workflow files, never
+  # `V.scala` (it has no custom/regex-manager support), so a Dependabot PR here
+  # always reverts on the next `ciCheckGithubWorkflow` regeneration and fails
+  # Lint (see #773). Bump pinned action versions manually: edit `V.scala`,
+  # run `sbt ciGenerateGithubWorkflow`, commit both together.
 
   # The Docusaurus site under website/ is built with npm by WebsitePlugin
   # (`npm install` / `npm run build`). Without this entry only Dependabot


### PR DESCRIPTION
## Summary
- Dependabot's `github-actions` ecosystem can only edit `uses:` lines in the *generated* `.github/workflows/*.yml` files, never `zio-sbt-ci`'s `V.scala` (the actual source of pinned action versions), and has no custom/regex-manager support to reach it (confirmed from `dependabot-core`'s file fetcher source).
- Every such PR therefore reverts on the next `ciCheckGithubWorkflow` regeneration and fails `Lint`, exactly as in #773.
- Removes the `github-actions` block from `.github/dependabot.yml`. The `npm` block for `website/` is untouched since it targets real `package.json`/lockfiles npm itself reads.
- Bumping a pinned action version is now a manual step: edit `V.scala`, run `sbt ciGenerateGithubWorkflow`, commit both together.

Closes #773 (that PR is superseded — no fix on the dependabot side is possible; see comment there).

## Test plan
- [x] `.github/dependabot.yml` still parses as valid YAML with just the `npm` block
- [x] No other file references the removed `github-actions` schedule/config