### PR TITLE
docs: add enable snippet + rename ciEnableNetlifyDeployPreview to ciEnableDeployPreview

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,10 +203,10 @@ The default value mirrors the bots used by the `zio/zio` repository: `Seq(Depend
 
 ### Netlify Deploy Previews
 
-Setting `ciEnableNetlifyDeployPreview := true` makes `ciGenerateGithubWorkflow` also generate `deploy-preview.yml`, which deploys the built Docusaurus site to Netlify for every pull request that touches `docs/` or `website/`.
+Setting `ciEnableDeployPreview := true` makes `ciGenerateGithubWorkflow` also generate `deploy-preview.yml`, which deploys the built Docusaurus site to Netlify for every pull request that touches `docs/` or `website/`.
 
 ```scala
-ThisBuild / ciEnableNetlifyDeployPreview := true
+ThisBuild / ciEnableDeployPreview := true
 ```
 
 The feature is split across two workflows, decoupled by artifacts rather than triggering the deploy directly from a pull request event:
@@ -218,9 +218,9 @@ Using `workflow_run` instead of triggering directly on `pull_request` means the 
 
 `deploy-preview.yml` triggers on *every* successful pull-request CI run, not only the ones where `build` actually uploaded artifacts — a PR that doesn't touch `docs/`/`website/`, or a repo with no website installed yet, never produces `website-artifact`/`pr-metadata` at all. To handle that, the two `actions/download-artifact` steps set `continue-on-error: true`, since a missing artifact there is an expected outcome, not a failure worth stopping the job over; every step after them then checks `steps.download-website.outcome == 'success' && steps.download-pr-metadata.outcome == 'success'` before running. So a run with nothing to deploy ends with two soft-failed downloads and nothing else — no deploy call, no PR comment — instead of a hard job failure.
 
-Put together, this makes `ciEnableNetlifyDeployPreview` safe to turn on before the Docusaurus site exists: neither workflow does any real work until `website/` is a genuine installation and a pull request actually changes it.
+Put together, this makes `ciEnableDeployPreview` safe to turn on before the Docusaurus site exists: neither workflow does any real work until `website/` is a genuine installation and a pull request actually changes it.
 
-This requires two repository secrets: `NETLIFY_AUTH_TOKEN`, a [personal access token](https://docs.netlify.com/api/get-started/#authentication) generated from the Netlify user account that owns the site, and `NETLIFY_SITE_ID`, found under the site's **Site configuration → General → Site details** in the Netlify dashboard. The default value of `ciEnableNetlifyDeployPreview` is `false`, so existing builds see no change until they opt in.
+This requires two repository secrets: `NETLIFY_AUTH_TOKEN`, a [personal access token](https://docs.netlify.com/api/get-started/#authentication) generated from the Netlify user account that owns the site, and `NETLIFY_SITE_ID`, found under the site's **Site configuration → General → Site details** in the Netlify dashboard. The default value of `ciEnableDeployPreview` is `false`, so existing builds see no change until they opt in.
 
 ### Keeping the Workflow in Sync
 
@@ -248,7 +248,7 @@ All settings are `ThisBuild`-scoped.
 | `ciConcurrency` | `Option[Concurrency]` | one run per branch, cancelling in progress | Concurrency group, or `None` to omit the block |
 | `ciSwapSizeGB` | `Int` | `0` | Adds a swap-space step to every job when greater than zero |
 | `ciBackgroundJobs` | `Seq[String]` | `Seq.empty` | Commands prefixed to each `run`, for daemons a job needs |
-| `ciEnableNetlifyDeployPreview` | `Boolean` | `false` | Adds website-artifact upload steps to `build` and generates `deploy-preview.yml`. Requires `NETLIFY_AUTH_TOKEN`/`NETLIFY_SITE_ID` secrets |
+| `ciEnableDeployPreview` | `Boolean` | `false` | Adds website-artifact upload steps to `build` and generates `deploy-preview.yml`. Requires `NETLIFY_AUTH_TOKEN`/`NETLIFY_SITE_ID` secrets |
 
 **Test matrix**
 
@@ -291,7 +291,7 @@ All settings are `ThisBuild`-scoped.
 
 | Task | Description |
 | --- | --- |
-| `ciGenerateGithubWorkflow` | Writes `ci.yml`, `auto-approve.yml` and `auto-merge.yml`, plus `deploy-preview.yml` when `ciEnableNetlifyDeployPreview` is `true` |
+| `ciGenerateGithubWorkflow` | Writes `ci.yml`, `auto-approve.yml` and `auto-merge.yml`, plus `deploy-preview.yml` when `ciEnableDeployPreview` is `true` |
 | `ciCheckGithubWorkflow` | Regenerates and fails if the committed files are stale |
 | `ciGenerateAutoApproveWorkflow` | Writes `auto-approve.yml` only |
 | `ciGenerateAutoMergeWorkflow` | Writes `auto-merge.yml` only |

--- a/README.md
+++ b/README.md
@@ -205,6 +205,10 @@ The default value mirrors the bots used by the `zio/zio` repository: `Seq(Depend
 
 Setting `ciEnableNetlifyDeployPreview := true` makes `ciGenerateGithubWorkflow` also generate `deploy-preview.yml`, which deploys the built Docusaurus site to Netlify for every pull request that touches `docs/` or `website/`.
 
+```scala
+ThisBuild / ciEnableNetlifyDeployPreview := true
+```
+
 The feature is split across two workflows, decoupled by artifacts rather than triggering the deploy directly from a pull request event:
 
 - The `build` job gains a few extra steps. `Check website is installed` runs first, checking that `website/package.json` and `website/docusaurus.config.js` both exist — the same signal [`installWebsite`](#zio-sbt-website) itself uses to tell a real Docusaurus scaffold apart from a `website/` directory holding only `mdocOut`'s generated output. Only when the website is installed does the job go on to detect whether the pull request touched `docs/` or `website/`, and if so upload `website/build` as a `website-artifact`, plus the PR number as a `pr-metadata` artifact.

--- a/build.sbt
+++ b/build.sbt
@@ -65,7 +65,7 @@ inThisBuild(
     ciEnabledBranches := Seq("main"),
     // The docs site already has NETLIFY_AUTH_TOKEN/NETLIFY_SITE_ID secrets configured, so this
     // repo dogfoods deploy previews for its own Docusaurus site (website/build).
-    ciEnableNetlifyDeployPreview := true
+    ciEnableDeployPreview := true
   )
 )
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -202,10 +202,10 @@ The default value mirrors the bots used by the `zio/zio` repository: `Seq(Depend
 
 ### Netlify Deploy Previews
 
-Setting `ciEnableNetlifyDeployPreview := true` makes `ciGenerateGithubWorkflow` also generate `deploy-preview.yml`, which deploys the built Docusaurus site to Netlify for every pull request that touches `docs/` or `website/`.
+Setting `ciEnableDeployPreview := true` makes `ciGenerateGithubWorkflow` also generate `deploy-preview.yml`, which deploys the built Docusaurus site to Netlify for every pull request that touches `docs/` or `website/`.
 
 ```scala
-ThisBuild / ciEnableNetlifyDeployPreview := true
+ThisBuild / ciEnableDeployPreview := true
 ```
 
 The feature is split across two workflows, decoupled by artifacts rather than triggering the deploy directly from a pull request event:
@@ -217,9 +217,9 @@ Using `workflow_run` instead of triggering directly on `pull_request` means the 
 
 `deploy-preview.yml` triggers on *every* successful pull-request CI run, not only the ones where `build` actually uploaded artifacts — a PR that doesn't touch `docs/`/`website/`, or a repo with no website installed yet, never produces `website-artifact`/`pr-metadata` at all. To handle that, the two `actions/download-artifact` steps set `continue-on-error: true`, since a missing artifact there is an expected outcome, not a failure worth stopping the job over; every step after them then checks `steps.download-website.outcome == 'success' && steps.download-pr-metadata.outcome == 'success'` before running. So a run with nothing to deploy ends with two soft-failed downloads and nothing else — no deploy call, no PR comment — instead of a hard job failure.
 
-Put together, this makes `ciEnableNetlifyDeployPreview` safe to turn on before the Docusaurus site exists: neither workflow does any real work until `website/` is a genuine installation and a pull request actually changes it.
+Put together, this makes `ciEnableDeployPreview` safe to turn on before the Docusaurus site exists: neither workflow does any real work until `website/` is a genuine installation and a pull request actually changes it.
 
-This requires two repository secrets: `NETLIFY_AUTH_TOKEN`, a [personal access token](https://docs.netlify.com/api/get-started/#authentication) generated from the Netlify user account that owns the site, and `NETLIFY_SITE_ID`, found under the site's **Site configuration → General → Site details** in the Netlify dashboard. The default value of `ciEnableNetlifyDeployPreview` is `false`, so existing builds see no change until they opt in.
+This requires two repository secrets: `NETLIFY_AUTH_TOKEN`, a [personal access token](https://docs.netlify.com/api/get-started/#authentication) generated from the Netlify user account that owns the site, and `NETLIFY_SITE_ID`, found under the site's **Site configuration → General → Site details** in the Netlify dashboard. The default value of `ciEnableDeployPreview` is `false`, so existing builds see no change until they opt in.
 
 ### Keeping the Workflow in Sync
 
@@ -247,7 +247,7 @@ All settings are `ThisBuild`-scoped.
 | `ciConcurrency` | `Option[Concurrency]` | one run per branch, cancelling in progress | Concurrency group, or `None` to omit the block |
 | `ciSwapSizeGB` | `Int` | `0` | Adds a swap-space step to every job when greater than zero |
 | `ciBackgroundJobs` | `Seq[String]` | `Seq.empty` | Commands prefixed to each `run`, for daemons a job needs |
-| `ciEnableNetlifyDeployPreview` | `Boolean` | `false` | Adds website-artifact upload steps to `build` and generates `deploy-preview.yml`. Requires `NETLIFY_AUTH_TOKEN`/`NETLIFY_SITE_ID` secrets |
+| `ciEnableDeployPreview` | `Boolean` | `false` | Adds website-artifact upload steps to `build` and generates `deploy-preview.yml`. Requires `NETLIFY_AUTH_TOKEN`/`NETLIFY_SITE_ID` secrets |
 
 **Test matrix**
 
@@ -290,7 +290,7 @@ All settings are `ThisBuild`-scoped.
 
 | Task | Description |
 | --- | --- |
-| `ciGenerateGithubWorkflow` | Writes `ci.yml`, `auto-approve.yml` and `auto-merge.yml`, plus `deploy-preview.yml` when `ciEnableNetlifyDeployPreview` is `true` |
+| `ciGenerateGithubWorkflow` | Writes `ci.yml`, `auto-approve.yml` and `auto-merge.yml`, plus `deploy-preview.yml` when `ciEnableDeployPreview` is `true` |
 | `ciCheckGithubWorkflow` | Regenerates and fails if the committed files are stale |
 | `ciGenerateAutoApproveWorkflow` | Writes `auto-approve.yml` only |
 | `ciGenerateAutoMergeWorkflow` | Writes `auto-merge.yml` only |

--- a/docs/index.md
+++ b/docs/index.md
@@ -204,6 +204,10 @@ The default value mirrors the bots used by the `zio/zio` repository: `Seq(Depend
 
 Setting `ciEnableNetlifyDeployPreview := true` makes `ciGenerateGithubWorkflow` also generate `deploy-preview.yml`, which deploys the built Docusaurus site to Netlify for every pull request that touches `docs/` or `website/`.
 
+```scala
+ThisBuild / ciEnableNetlifyDeployPreview := true
+```
+
 The feature is split across two workflows, decoupled by artifacts rather than triggering the deploy directly from a pull request event:
 
 - The `build` job gains a few extra steps. `Check website is installed` runs first, checking that `website/package.json` and `website/docusaurus.config.js` both exist — the same signal [`installWebsite`](#zio-sbt-website) itself uses to tell a real Docusaurus scaffold apart from a `website/` directory holding only `mdocOut`'s generated output. Only when the website is installed does the job go on to detect whether the pull request touched `docs/` or `website/`, and if so upload `website/build` as a `website-artifact`, plus the PR number as a `pr-metadata` artifact.

--- a/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
+++ b/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
@@ -95,7 +95,7 @@ object ZioSbtCiPlugin extends AutoPlugin {
       settingKey[Seq[Step]]("Workflow steps for checking artifact build process")
     val ciCheckWebsiteBuildProcess: SettingKey[Seq[Step]] =
       settingKey[Seq[Step]]("Workflow steps for checking website build process")
-    val ciEnableNetlifyDeployPreview: SettingKey[Boolean] =
+    val ciEnableDeployPreview: SettingKey[Boolean] =
       settingKey[Boolean](
         "When true, adds change-detection and website-artifact upload steps to the build job, " +
           "and makes `ciGenerateGithubWorkflow` also generate deploy-preview.yml, which deploys " +
@@ -185,7 +185,7 @@ object ZioSbtCiPlugin extends AutoPlugin {
     val checkArtifactBuildProcess = ciCheckArtifactsBuildSteps.value
     val checkWebsiteBuildProcess  = ciCheckWebsiteBuildProcess.value
     val netlifyPreviewBuildSteps  =
-      if (ciEnableNetlifyDeployPreview.value) NetlifyPreviewBuildSteps.value else Seq.empty
+      if (ciEnableDeployPreview.value) NetlifyPreviewBuildSteps.value else Seq.empty
 
     Seq(
       Job(
@@ -1004,7 +1004,7 @@ object ZioSbtCiPlugin extends AutoPlugin {
   lazy val generateNetlifyDeployPreviewWorkflowTask: Def.Initialize[Task[Unit]] =
     Def.task {
       val baseDir  = (ThisBuild / Keys.baseDirectory).value
-      val enabled  = ciEnableNetlifyDeployPreview.value
+      val enabled  = ciEnableDeployPreview.value
       val workflow = netlifyDeployPreviewWorkflow.value
 
       if (enabled)
@@ -1064,7 +1064,7 @@ object ZioSbtCiPlugin extends AutoPlugin {
           )
         ),
       ciCheckWebsiteBuildProcess       := CheckWebsiteBuildProcess.value,
-      ciEnableNetlifyDeployPreview     := false,
+      ciEnableDeployPreview            := false,
       ciCheckArtifactsCompilationSteps := Seq(
         Step.SingleStep(
           name = "Check all code compiles",

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/netlifyDeployPreview/build.sbt
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/netlifyDeployPreview/build.sbt
@@ -1,10 +1,10 @@
-// Pins the workflows generated with `ciEnableNetlifyDeployPreview := true`: the build job gains
+// Pins the workflows generated with `ciEnableDeployPreview := true`: the build job gains
 // the website-artifact/PR-metadata upload steps, and a fourth workflow file, deploy-preview.yml,
 // is generated alongside the usual three.
 
 ThisBuild / name := "Test Project"
 
-ThisBuild / ciEnableNetlifyDeployPreview := true
+ThisBuild / ciEnableDeployPreview := true
 
 lazy val root = (project in file("."))
   .settings(


### PR DESCRIPTION
## Summary
- Docs: the "Netlify Deploy Previews" section explained what the setting does but never showed the actual line to turn it on. Added the one-line snippet.
- Rename: `ciEnableNetlifyDeployPreview` → `ciEnableDeployPreview`. The setting only ever gates our own build-job/`deploy-preview.yml` logic — naming it after the current deploy target (Netlify) needlessly ties the key to an implementation detail. Purely a rename; generated workflow YAML is unaffected (verified via the `netlifyDeployPreview` scripted fixture, unchanged golden output).
- Doubles as another smoke test for the deploy-preview mechanism (#770/#772): this PR touches `docs/`, so it should trigger the website-artifact upload and a real Netlify preview + sticky comment.

## Test plan
- [x] `sbt +Test/compile` clean
- [x] `sbt "++2.13; lint"` clean
- [x] `netlifyDeployPreview`/`defaults`/`customJobs` scripted fixtures pass unchanged after the rename
- [ ] `deploy-preview.yml` fires after CI succeeds
- [ ] A sticky comment with the preview URL appears on this PR