### PR TITLE
Make Build job block merges on any failing step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    continue-on-error: true
+    continue-on-error: false
     steps:
     - name: Git Checkout
       uses: actions/checkout@v7.0.1

--- a/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
+++ b/zio-sbt-ci/src/main/scala/zio/sbt/ZioSbtCiPlugin.scala
@@ -191,7 +191,6 @@ object ZioSbtCiPlugin extends AutoPlugin {
       Job(
         id = "build",
         name = "Build",
-        continueOnError = true,
         steps = {
           (if (swapSizeGB > 0) Seq(setSwapSpace) else Seq.empty) ++
             Seq(

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/bothPlugins/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/bothPlugins/expected/ci.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    continue-on-error: true
+    continue-on-error: false
     steps:
     - name: Git Checkout
       uses: actions/checkout@v7.0.1

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/concurrency/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/concurrency/expected/ci.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    continue-on-error: true
+    continue-on-error: false
     steps:
     - name: Git Checkout
       uses: actions/checkout@v7.0.1

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/defaults-sbt2/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/defaults-sbt2/expected/ci.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    continue-on-error: true
+    continue-on-error: false
     steps:
     - name: Git Checkout
       uses: actions/checkout@v7.0.1

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/defaults/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/defaults/expected/ci.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    continue-on-error: true
+    continue-on-error: false
     steps:
     - name: Git Checkout
       uses: actions/checkout@v7.0.1

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/flattenTests/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/flattenTests/expected/ci.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    continue-on-error: true
+    continue-on-error: false
     steps:
     - name: Git Checkout
       uses: actions/checkout@v7.0.1

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/groupTests/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/groupTests/expected/ci.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    continue-on-error: true
+    continue-on-error: false
     steps:
     - name: Git Checkout
       uses: actions/checkout@v7.0.1

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/mappedJobs/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/mappedJobs/expected/ci.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-22.04
-    continue-on-error: true
+    continue-on-error: false
     steps:
     - name: Git Checkout
       uses: actions/checkout@v7.0.1

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/netlifyDeployPreview/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/netlifyDeployPreview/expected/ci.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    continue-on-error: true
+    continue-on-error: false
     steps:
     - name: Git Checkout
       uses: actions/checkout@v7.0.1

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/services/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/services/expected/ci.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    continue-on-error: true
+    continue-on-error: false
     steps:
     - name: Git Checkout
       uses: actions/checkout@v7.0.1

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/settingsOverrides/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/settingsOverrides/expected/ci.yml
@@ -27,7 +27,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    continue-on-error: true
+    continue-on-error: false
     steps:
     - name: Git Checkout
       uses: actions/checkout@v7.0.1

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowEnv/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowEnv/expected/ci.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    continue-on-error: true
+    continue-on-error: false
     steps:
     - name: Git Checkout
       uses: actions/checkout@v7.0.1

--- a/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowTriggers/expected/ci.yml
+++ b/zio-sbt-ci/src/sbt-test/zio-sbt-ci/workflowTriggers/expected/ci.yml
@@ -22,7 +22,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    continue-on-error: true
+    continue-on-error: false
     steps:
     - name: Git Checkout
       uses: actions/checkout@v7.0.1


### PR DESCRIPTION
## Summary

- Removes `continueOnError = true` from the generated `build` Job (`ZioSbtCiPlugin.scala`), so a real Build failure now propagates into the `ci` gate's `needs.build.result` and blocks merge, same as Lint/Test already do.
- Regenerates `.github/workflows/ci.yml` and re-records the 12 golden-file scripted fixtures under `zio-sbt-ci/src/sbt-test/zio-sbt-ci/*/expected/ci.yml` that pin the Build job's exact generated YAML.

## Why

`continueOnError: true` on Build meant a failing step there (compile, publishLocal, sbt-2.x scripted fixtures, website build) never flipped the required `ci` check red. That let the auto-merge bot (`app/zio-assistant`) merge PRs straight through a broken Build. PR #781 ("Update scala3-library to 3.9.0") broke the sbt-2.x scripted fixtures step this exact way, and it sat broken through 3 auto-merges (#781, #782, #784) before anyone noticed, since the top-level CI run still showed green.

This closes that gap: every CI step must be green before any PR — bot or human — merges. No carve-out is kept for the website build, so a flaky website build will also now block merges until fixed; this trade-off was made deliberately (see discussion).

## Out of scope (follow-up)

The actual currently-broken "Check sbt-2.x scripted fixtures" step is not fixed here. Root cause found while re-recording the `defaults-sbt2` golden fixture: `project/Versions.scala` pins `Scala3` to match the Scala version sbt 2.0.7 itself bundles (3.8.4, per the comment above the setting), but Renovate's PR #781 bumped it to 3.9.0 anyway — producing TASTy 28.9 class files that sbt 2.0.7's bundled 3.8.4 compiler (max TASTy 28.8) can't read. Reverting `Scala3` to `"3.8.4"` fixes it (verified locally); a follow-up PR should do that plus add a Renovate ignore rule so it doesn't drift again.

## Test plan

- [x] `sbt lint` passes
- [x] `sbt ciGenerateGithubWorkflow` — root `ci.yml` diff is exactly the one `continue-on-error` line
- [x] Re-recorded and re-ran all 12 affected scripted fixtures (`defaults`, `defaults-sbt2`, `concurrency`, `flattenTests`, `bothPlugins`, `groupTests`, `mappedJobs`, `services`, `netlifyDeployPreview`, `workflowTriggers`, `workflowEnv`, `settingsOverrides`) — all pass, each diff is exactly the `continue-on-error` flip
- [ ] Note: this PR's own CI will currently fail on "Check sbt-2.x scripted fixtures" (the pre-existing #781 regression described above) — expected, since Build is no longer masked. Needs the follow-up Scala3 pin fix merged first (or alongside) for this PR's own CI to go green.