### PR TITLE
Revert Scala3 to 3.8.4 to fix sbt-2.x scripted fixtures

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -13,13 +13,5 @@
 #
 # Remove once the sbt 2 migration lands.
 updates.pin = [
-  { groupId = "org.scala-sbt", artifactId = "sbt", version = "1." },
-
-  # Hold Scala3 (project/Versions.scala) on the 3.8.x series: it must match the Scala 3 version
-  # sbt 2.0.7 itself bundles (3.8.4), not the newest Scala 3 release. #781 bumped it to 3.9.0 and
-  # broke the sbt-2.x scripted fixtures: sbt 2.0.7's bundled 3.8.4 compiler can only read TASTy up
-  # to version 28.8, and 3.9.0 emits TASTy 28.9.
-  #
-  # Remove once sbt itself bundles a newer Scala 3 (bump this alongside that).
-  { groupId = "org.scala-lang", artifactId = "scala3-library", version = "3.8." }
+  { groupId = "org.scala-sbt", artifactId = "sbt", version = "1." }
 ]

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -13,5 +13,13 @@
 #
 # Remove once the sbt 2 migration lands.
 updates.pin = [
-  { groupId = "org.scala-sbt", artifactId = "sbt", version = "1." }
+  { groupId = "org.scala-sbt", artifactId = "sbt", version = "1." },
+
+  # Hold Scala3 (project/Versions.scala) on the 3.8.x series: it must match the Scala 3 version
+  # sbt 2.0.7 itself bundles (3.8.4), not the newest Scala 3 release. #781 bumped it to 3.9.0 and
+  # broke the sbt-2.x scripted fixtures: sbt 2.0.7's bundled 3.8.4 compiler can only read TASTy up
+  # to version 28.8, and 3.9.0 emits TASTy 28.9.
+  #
+  # Remove once sbt itself bundles a newer Scala 3 (bump this alongside that).
+  { groupId = "org.scala-lang", artifactId = "scala3-library", version = "3.8." }
 ]

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -5,6 +5,6 @@ object Versions {
   // Scala 3 release): Scala 3.3.8 hits a dotc compiler crash ("module class X$ has non-class
   // parent") when a downstream module cross-module-TASTy-references a sealed trait's companion,
   // which 3.8.4 does not reproduce.
-  val Scala3 = "3.9.0"
+  val Scala3 = "3.8.4"
   val zio    = "2.1.26"
 }


### PR DESCRIPTION
## Summary

- Reverts `project/Versions.scala`'s `Scala3` from `3.9.0` back to `3.8.4`.

## Why

The comment already above the `Scala3` setting says it's pinned to match the Scala 3 version sbt 2.0.7 itself bundles, not the newest available Scala 3 release: sbt 2.0.7's bundled compiler is 3.8.4. PR #781 (Scala Steward) bumped it to 3.9.0 anyway - Scala Steward has no way to know about that constraint, since it's just a plain `val`, not a recognized "hold" dependency.

3.9.0 emits TASTy version 28.9; sbt 2.0.7's bundled 3.8.4 compiler can only read TASTy up to 28.8. That broke all three sbt-2.x scripted fixtures:
- `zio-sbt-ecosystem/verifySettings-sbt2` - `value autoImport is not a member of object zio.sbt.ZioSbtEcosystemPlugin` / `Reference to project is ambiguous`
- `zio-sbt-website/installWebsite-sbt2`
- `zio-sbt-ci/defaults-sbt2` - `error while loading language, ... Forward incompatible TASTy file has version 28.9 ... expected stable TASTy from 28.0 to 28.8`

This sat broken through 3 auto-merges (#781, #782, #784) because the Build job's `continueOnError: true` masked it from the required `ci` check (see #785, which removes that masking).

## Test plan

- [x] Reproduced the exact CI step locally: `sbt "+publishLocal" "zio-sbt-ecosystem/scripted zio-sbt-ecosystem/verifySettings-sbt2" "zio-sbt-website/scripted zio-sbt-website/installWebsite-sbt2" "zio-sbt-ci/scripted zio-sbt-ci/defaults-sbt2"` - all three now pass (previously failed on `main`)
- [x] `sbt lint` passes
- [x] `sbt "+Test/compile"` passes

## Related

Companion to #785 (removes the Build job's `continueOnError`, which is what let this regression merge unnoticed in the first place). Both should land for CI to be fully green end-to-end.