### PR TITLE
Default to Scala 3.9.0 and Java 17, and drop Java 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Both forms emit `showLineNumbers` in the code fence header, enabling line number
 
 ### Default Testing Strategy
 
-The default testing strategy for ZIO SBT CI plugin is to run `sbt +test` on Corretto Java 11, 17 and 21. So this will generate the following job:
+The default testing strategy for ZIO SBT CI plugin is to run `sbt +test` on Corretto Java 17, 21 and 25. So this will generate the following job:
 
 ```yaml
 test:
@@ -255,7 +255,7 @@ test:
   strategy:
     fail-fast: false
     matrix:
-      java: ['11', '17', '21']
+      java: ['17', '21', '25']
   steps:
   - name: Install libuv
     run: sudo apt-get update && sudo apt-get install -y libuv1-dev
@@ -319,7 +319,7 @@ test:
   strategy:
     fail-fast: false
     matrix:
-      java: ['11', '17', '21']
+      java: ['17', '21', '25']
       scala-project:
       - ++2.12.20 submoduleA
       - ++2.12.20 submoduleB

--- a/docs/index.md
+++ b/docs/index.md
@@ -244,7 +244,7 @@ Both forms emit `showLineNumbers` in the code fence header, enabling line number
 
 ### Default Testing Strategy
 
-The default testing strategy for ZIO SBT CI plugin is to run `sbt +test` on Corretto Java 11, 17 and 21. So this will generate the following job:
+The default testing strategy for ZIO SBT CI plugin is to run `sbt +test` on Corretto Java 17, 21 and 25. So this will generate the following job:
 
 ```yaml
 test:
@@ -254,7 +254,7 @@ test:
   strategy:
     fail-fast: false
     matrix:
-      java: ['11', '17', '21']
+      java: ['17', '21', '25']
   steps:
   - name: Install libuv
     run: sudo apt-get update && sudo apt-get install -y libuv1-dev
@@ -318,7 +318,7 @@ test:
   strategy:
     fail-fast: false
     matrix:
-      java: ['11', '17', '21']
+      java: ['17', '21', '25']
       scala-project:
       - ++2.12.20 submoduleA
       - ++2.12.20 submoduleB

--- a/zio-sbt-ecosystem/src/main/scala/zio/sbt/ScalaCompilerSettings.scala
+++ b/zio-sbt-ecosystem/src/main/scala/zio/sbt/ScalaCompilerSettings.scala
@@ -158,7 +158,7 @@ trait ScalaCompilerSettings {
   def stdSettings(
     name: Option[String] = None,
     packageName: Option[String] = None,
-    javaPlatform: String = "11",
+    javaPlatform: String = "17",
     enableKindProjector: Boolean = true,
     enableCrossProject: Boolean = false,
     enableScalafix: Boolean = true,

--- a/zio-sbt-ecosystem/src/main/scala/zio/sbt/Versions.scala
+++ b/zio-sbt-ecosystem/src/main/scala/zio/sbt/Versions.scala
@@ -22,7 +22,7 @@ object Versions {
   val KindProjectorVersion = "0.13.4"
   val ScaluzziVersion      = "0.1.23"
 
-  val scala3   = "3.3.8"
+  val scala3   = "3.9.0"
   val scala212 = "2.12.21"
   val scala213 = "2.13.18"
 

--- a/zio-sbt-ecosystem/src/main/scala/zio/sbt/ZioSbtEcosystemPlugin.scala
+++ b/zio-sbt-ecosystem/src/main/scala/zio/sbt/ZioSbtEcosystemPlugin.scala
@@ -109,7 +109,7 @@ object ZioSbtEcosystemPlugin extends AutoPlugin {
     scalaVersion       := scala213.value,
     crossScalaVersions := Seq(scala212.value, scala213.value, scala3.value),
     zioVersion         := Versions.zioVersion,
-    javaPlatform       := "11"
+    javaPlatform       := "17"
   )
 
   override def globalSettings: Seq[Def.Setting[_]] =

--- a/zio-sbt-githubactions/src/main/scala/zio/sbt/githubactions/ScalaWorkflow.scala
+++ b/zio-sbt-githubactions/src/main/scala/zio/sbt/githubactions/ScalaWorkflow.scala
@@ -17,7 +17,7 @@
 package zio.sbt.githubactions
 
 import zio.json.ast.Json
-import zio.sbt.githubactions.ScalaWorkflow.JavaVersion.JDK11
+import zio.sbt.githubactions.ScalaWorkflow.JavaVersion.JDK17
 
 // The original code of the githubactions package was originally copied from the zio-aws-codegen project:
 // https://github.com/zio/zio-aws/tree/master/zio-aws-codegen/src/main/scala/zio/aws/codegen/githubactions
@@ -227,7 +227,6 @@ object ScalaWorkflow {
       override val asString: String = s"corretto:$javaVersion"
     }
 
-    val JDK11: JavaVersion = CorrettoJDK("11")
     val JDK17: JavaVersion = CorrettoJDK("17")
     val JDK21: JavaVersion = CorrettoJDK("21")
     val JDK25: JavaVersion = CorrettoJDK("25")
@@ -237,7 +236,7 @@ object ScalaWorkflow {
     def matrix(
       scalaVersions: Seq[ScalaVersion],
       operatingSystems: Seq[OS] = Seq(OS.UbuntuLatest),
-      javaVersions: Seq[JavaVersion] = Seq(JDK11)
+      javaVersions: Seq[JavaVersion] = Seq(JDK17)
     ): Job =
       job.copy(
         strategy = Some(


### PR DESCRIPTION
## Summary

Moves the ecosystem defaults forward and removes Java 11:

| default | before | after |
|---|---|---|
| `Versions.scala3` | 3.3.8 | **3.9.0** |
| `stdSettings(javaPlatform = …)` | `"11"` | **`"17"`** |
| `javaPlatform` setting key | `"11"` | **`"17"`** |
| `ScalaWorkflow` matrix `javaVersions` | `Seq(JDK11)` | **`Seq(JDK17)`** |
| `JavaVersion.JDK11` | present | **removed** |

## Why the two defaults have to move together

Scala 3.9 dropped Java 11 as a compile target. A build that picked up the new Scala 3 default while keeping `javaPlatform = "11"` fails to compile:

```
[error] 11 is not a valid choice for -java-output-version
```

That is not hypothetical — it is what several downstream repos hit, and each had to work around it by passing `javaPlatform = "17"` to `stdSettings` by hand. Shipping the two defaults together means downstream builds get a consistent pair.

## Java 11 removal

`ciTargetJavaVersions` already defaulted to `Seq("17", "21", "25")`, so the generated CI matrices had dropped 11 some time ago. What remained were:

- `JavaVersion.JDK11`, and the `ScalaWorkflow` matrix helper still defaulting to it;
- the README and `docs/index.md`, which still described the default strategy as *"Corretto Java 11, 17 and 21"* and showed a `java: ['11', '17', '21']` matrix. Both now say 17, 21 and 25, matching what the plugin actually generates.

## Notes

- `project/Versions.scala` (this repo's own cross-build Scala 3 version) is deliberately left at 3.3.8 — that governs how zio-sbt itself is built, not what it hands downstream.
- `scala3Settings` already strips `-Xfatal-warnings` for Scala 3, so no change was needed there for 3.9.

## Verification

`compile` and `Test/compile` are clean. The scripted tests do not run in my environment — they fail during project load with `fatal: not a git repository`, and they fail identically on an unmodified `main`, so that is pre-existing and environmental rather than related to this change. CI will exercise them properly.